### PR TITLE
Babel-ify integration tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,10 +5,9 @@
       "@babel/preset-env",
       {
         "targets": {
-          "firefox": "63"
-        },
-        "useBuiltIns": "usage",
-        "modules": false
+          "firefox": "63",
+          "node": "10",
+        }
       }
     ]
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -787,6 +787,45 @@
         "@babel/plugin-transform-react-jsx-source": "^7.0.0"
       }
     },
+    "@babel/register": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.0.0.tgz",
+      "integrity": "sha512-f/+CRmaCe7rVEvcvPvxeA8j5aJhHC3aJie7YuqcMDhUOuyWLA7J/aNrTaHIzoWPEhpHA54mec4Mm8fv8KBlv3g==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.5.7",
+        "find-cache-dir": "^1.0.0",
+        "home-or-tmp": "^3.0.0",
+        "lodash": "^4.17.10",
+        "mkdirp": "^0.5.1",
+        "pirates": "^4.0.0",
+        "source-map-support": "^0.5.9"
+      },
+      "dependencies": {
+        "home-or-tmp": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-3.0.0.tgz",
+          "integrity": "sha1-V6j+JM8zzdUkhgoVgh3cJchmcfs=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.9",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+          "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
+      }
+    },
     "@babel/runtime": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.2.tgz",
@@ -9763,6 +9802,12 @@
         }
       }
     },
+    "node-modules-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+      "dev": true
+    },
     "node-notifier": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
@@ -10519,6 +10564,15 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.2.1.tgz",
       "integrity": "sha512-QqL7kkF7eMCpFG4hpZD8UPQga/kxkkh3E62HzMzTIL4OQyijyisAnBL8msBEAml8xcb/ioGhH7UUzGxuHqczhQ==",
       "dev": true
+    },
+    "pirates": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.0.tgz",
+      "integrity": "sha512-8t5BsXy1LUIjn3WWOlOuFDuKswhQb/tkak641lvBgmPOBUQHXveORtlMCp6OdPV1dtuTaEahKA8VNz6uLfKBtA==",
+      "dev": true,
+      "requires": {
+        "node-modules-regexp": "^1.0.0"
+      }
     },
     "pkg-dir": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "pretest": "npm run autolint && npm run clean:coverage",
     "test": "cross-env NODE_ENV=test karma start --single-run",
     "preintegration": "npm run build",
-    "integration": "cross-env NODE_ENV=test MOZ_HEADLESS=1 mocha --timeout 10000 test/integration",
+    "integration": "cross-env NODE_ENV=test MOZ_HEADLESS=1 mocha --require @babel/register --timeout 10000 test/integration",
     "codecov": "codecov"
   },
   "author": "Lockbox Team <lockbox-dev@mozilla.com>",
@@ -40,6 +40,7 @@
     "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
+    "@babel/register": "^7.0.0",
     "async-wait-until": "^1.2.4",
     "babel-loader": "^8.0.4",
     "babel-plugin-istanbul": "^5.0.1",

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -4,15 +4,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-const PATH = require("path");
-const chai = require("chai");
-const chaiAsPromised = require("chai-as-promised");
-const webExtensionsGeckoDriver = require("webextensions-geckodriver");
+import chai, { expect } from "chai";
+import PATH from "path";
+import chaiAsPromised from "chai-as-promised";
+import webExtensionsGeckoDriver, { webdriver } from "webextensions-geckodriver";
 
-const { expect } = chai;
 chai.use(chaiAsPromised);
 
-const { webdriver } = webExtensionsGeckoDriver;
 const manifest = PATH.resolve(__dirname, "../../dist/manifest.json");
 const ident = "lockbox_mozilla_com";
 
@@ -20,7 +18,9 @@ describe("Lockbox functional testing", () => {
   let driver, helper;
 
   before(async () => {
-    const webext = await webExtensionsGeckoDriver(manifest);
+    const webext = await webExtensionsGeckoDriver(manifest, {
+      webExt: { artifactsDir: PATH.resolve("../../addons/") },
+    });
     driver = webext.geckodriver;
     helper = {
       toolbar() {


### PR DESCRIPTION
Use babel to make the integration tests ES2018 compatible (`import`, `async/await`, Object rest spread, etc).