### PR TITLE
Refactor integration/accessibility tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 _aliases:
   - &node
     addons:
-      firefox: latest
+      firefox: latest-unsigned
     language: node_js
     node_js: stable
 

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,17 +1,13 @@
 # lockbox-extension code owners
 # https://help.github.com/articles/about-codeowners/
 
-# integration tests and related config are maintained by PI
-/test/integration/          @mozilla-lockbox/product-integrity
-
 # test plans are maintained by PI
 /docs/developer/test-plan*  @mozilla-lockbox/product-integrity
 
 # metrics docs are maintained by Leif
 /docs/metrics.md            @irrationalagent 
 
-# unit tests and related config are maintained by engineering
-/test/unit/                 @mozilla-lockbox/desktop-engineering
+# tests and related config are maintained by engineering
 /test/                      @mozilla-lockbox/desktop-engineering
 
 # source code and all other docs are maintained by engineering

--- a/docs/developer/install.md
+++ b/docs/developer/install.md
@@ -76,3 +76,48 @@ example data) using Firefox Nightly, you can just run (without adding flags):
 ```sh
 npm run run
 ```
+
+## Testing the extension
+
+There are two forms of autmomated testing present: unit (test individual classes as much in isolation to everything else -- including the browser internals) and integration.
+
+To run the unit tests, you can run:
+
+```sh
+npm run test
+```
+
+or simply
+
+```sh
+npm test
+```
+
+This runs tests using Firefox, but wholly as "web content" (what most web pages are).
+
+To run the integration tests, you can run:
+
+```sh
+npm run integration
+```
+
+This drives Firefox via Selenium, driving an instance of Firefox with this addon installed.
+
+By default, it searches for which Firefox by searching for one of the following channels (in this order):
+
+* Nightly
+* Aurora (Selenium's codename for Developer Edition)
+* Beta
+* Release
+
+You can tell it which Firefox to use by setting the `LOCKBOX_FIREFOX_BINARY` environment variable -- either as one of the channel names or the full path to the `firefox` binary:
+
+```sh
+LOCKBOX_FIREFOX_BINARY=beta npm run integration
+```
+
+By default, the integration tests are **NOT** run in headless mode -- each test will result in a Firefox window opening when it starts and closing when it ends.  You can run the integration tests in headless mode by setting the `LOCKBOX_FIREFOX_HEADLESS` environment variable to `1`:
+
+```sh
+LOCKBOX_FIREFOX_HEADLESS=1 npm run integration
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -2019,6 +2019,31 @@
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
+    "axe-core": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.1.2.tgz",
+      "integrity": "sha512-e1WVs0SQu3tM29J9a/mISGvlo2kdCStE+yffIAJF6eb42FS+eUFEVz9j4rgDeV2TAfPJmuOZdRetWYycIbK7Vg==",
+      "dev": true
+    },
+    "axe-webdriverjs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/axe-webdriverjs/-/axe-webdriverjs-2.1.0.tgz",
+      "integrity": "sha512-0gX7SvxSqnT2OTDTiAYJPlqw08Lt+dGW24jQhQHgYZCp1kSuP17koKUbNxJNhU1bHITYSz9pK64me7om2Wn6gA==",
+      "dev": true,
+      "requires": {
+        "axe-core": "^3.0.0",
+        "babel-runtime": "^6.26.0",
+        "depd": "^2.0.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+          "dev": true
+        }
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "pretest": "npm run autolint && npm run clean:coverage",
     "test": "cross-env NODE_ENV=test karma start --single-run",
     "preintegration": "cross-env NODE_ENV=test npm run build",
-    "integration": "cross-env NODE_ENV=test MOZ_HEADLESS=1 mocha --require @babel/register --timeout 10000 test/integration/**/*-test.js",
+    "integration": "cross-env NODE_ENV=test mocha --require @babel/register --timeout 10000 test/integration/**/*-test.js",
     "codecov": "codecov"
   },
   "author": "Lockbox Team <lockbox-dev@mozilla.com>",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "run": "cross-env-shell web-ext run --source-dir ./dist ${npm_config_webext_runflags}",
     "pretest": "npm run autolint && npm run clean:coverage",
     "test": "cross-env NODE_ENV=test karma start --single-run",
-    "preintegration": "npm run build",
-    "integration": "cross-env NODE_ENV=test MOZ_HEADLESS=1 mocha --require @babel/register --timeout 10000 test/integration",
+    "preintegration": "cross-env NODE_ENV=test npm run build",
+    "integration": "cross-env NODE_ENV=test MOZ_HEADLESS=1 mocha --require @babel/register --timeout 10000 test/integration/**/*-test.js",
     "codecov": "codecov"
   },
   "author": "Lockbox Team <lockbox-dev@mozilla.com>",
@@ -42,6 +42,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.0.0",
     "async-wait-until": "^1.2.4",
+    "axe-webdriverjs": "^2.1.0",
     "babel-loader": "^8.0.4",
     "babel-plugin-istanbul": "^5.0.1",
     "babel-plugin-rewire": "^1.2.0",

--- a/src/manifest.json.tpl
+++ b/src/manifest.json.tpl
@@ -8,6 +8,9 @@
     "96": "icons/lb_locked.svg"
   },
 
+
+  "content_security_policy": "script-src 'self' {{csp_scripts}} ; object-src 'self' {{csp_objects}}",
+
   "applications": {
     "gecko": {
       "id": "{{id}}",

--- a/src/manifest.json.tpl
+++ b/src/manifest.json.tpl
@@ -9,7 +9,7 @@
   },
 
 
-  "content_security_policy": "script-src 'self' {{csp_scripts}} ; object-src 'self' {{csp_objects}}",
+  "content_security_policy": "script-src 'self' {{testing_csp_scripts}} ; object-src 'self' {{testing_csp_objects}}",
 
   "applications": {
     "gecko": {

--- a/test/integration/a11y-test.js
+++ b/test/integration/a11y-test.js
@@ -1,0 +1,48 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import getWebExtension from "./driver";
+import AxeBuilder from "axe-webdriverjs";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+
+chai.use(chaiAsPromised);
+
+describe("accessibility", () => {
+  let webext;
+  let helper;
+
+  before(async () => {
+    webext = await getWebExtension();
+    await webext.start();
+
+    helper = {
+      async home() {
+        const url = webext.url("/list/manage.html");
+        const { driver, webdriver } = webext;
+        await driver.get(url);
+
+        return driver.wait(webdriver.until.elementLocated(
+          webdriver.By.css("main#content")
+        ), 1000);
+      },
+    };
+  });
+  after(async () => {
+    await webext.stop();
+  });
+
+  beforeEach(async () => {
+    await webext.inContent();
+  });
+
+  it("tests homepage", async () => {
+    await helper.home();
+
+    return AxeBuilder(webext.driver).
+      analyze();
+  });
+});

--- a/test/integration/a11y-test.js
+++ b/test/integration/a11y-test.js
@@ -37,7 +37,7 @@ describe("accessibility", () => {
     return AxeBuilder(webext.driver).
       analyze().
       then(results => {
-        expect(results).violations("critial").to.deep.equal([]);
+        expect(results).violations("critical").to.deep.equal([]);
       });
   });
 });

--- a/test/integration/chai-axe.js
+++ b/test/integration/chai-axe.js
@@ -1,0 +1,27 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+const IMPACTS = [
+  "minor", "moderate", "serious", "critical",
+];
+
+function filterImpact(results, impact) {
+  const min = IMPACTS.indexOf(impact || "minor");
+  return (results || []).filter((r) => IMPACTS.indexOf(r.impact) >= min);
+}
+
+export default function axeResults(chai, utils) {
+  const Assertion = chai.Assertion;
+
+  function filterViolations(impact) {
+    let target = utils.flag(this, "object");
+    target = target && target.violations;
+    target = filterImpact(target, impact);
+    utils.flag(this, "object", target);
+  }
+
+  Assertion.addChainableMethod("violations", filterViolations, filterViolations);
+}

--- a/test/integration/driver.js
+++ b/test/integration/driver.js
@@ -59,6 +59,7 @@ export class WebExtensionDriver {
 
   get driver() { return this.webext && this.webext.driver; }
   get id() { return this.webext && this.webext.id; }
+  get baseURL() { return (this.webext && this.webext.baseURL) || ""; }
 
   url(path) {
     if (!this.running) {
@@ -68,7 +69,7 @@ export class WebExtensionDriver {
       path = "";
     }
 
-    return `${this.webext.baseURL}${path}`;
+    return `${this.baseURL}${path}`;
   }
 
   async inContent() {

--- a/test/integration/driver.js
+++ b/test/integration/driver.js
@@ -1,0 +1,142 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import "geckodriver";
+
+import PATH from "path";
+import WebExtUtil from "web-ext";
+import webdriver from "selenium-webdriver";
+import firefox from "selenium-webdriver/firefox";
+
+const DEFAULT_PREFS = {
+  "xpinstall.signatures.required": false,
+  "devtools.chrome.enabled": true,
+  "devtools.debugger.remote-enabled": true,
+};
+
+export class WebExtensionDriver {
+  constructor(manifest, opts) {
+    this.manifest = manifest;
+    this.options = { ...opts };
+  }
+
+  async initialize() {
+    if (this.webext) {
+      return this.webext;
+    }
+
+    const sourceDir = PATH.dirname(this.manifest);
+    const artifactsDir = PATH.resolve(sourceDir, "../addons");
+    const info = await WebExtUtil.cmd.build({
+      sourceDir,
+      artifactsDir,
+      overwriteDest: true,
+    });
+
+    this.webext = info;
+
+    return this;
+  }
+
+  get running() { return !!(this.webext && this.webext.id); }
+  get firefox() { return firefox; }
+  get webdriver() { return webdriver; }
+
+  get driver() { return this.webext && this.webext.driver; }
+  get id() { return this.webext && this.webext.id; }
+
+  url(path) {
+    if (!this.running) {
+      return "";
+    }
+    if (!path) {
+      path = "";
+    }
+
+    return `${this.webext.baseURL}${path}`;
+  }
+
+  async inContent() {
+    if (this.running) {
+      const driver = this.driver;
+      await driver.setContext(this.firefox.Context.CONTENT);
+    }
+  }
+  async inChrome() {
+    if (this.running) {
+      const driver = this.driver;
+      await driver.setContext(this.firefox.Context.CHROME);
+    }
+  }
+
+  async start() {
+    if (this.running) {
+      return this;
+    }
+
+    // build the driver driver
+    let fxOpts = new firefox.Options();
+
+    let fxPrefs = this.options.preferences || {};
+    fxPrefs = {
+      ...fxPrefs,
+      ...DEFAULT_PREFS,
+    };
+    Object.entries(fxPrefs).forEach((e) => {
+      const [key, value] = e;
+      fxOpts.setPreference(key, value);
+    });
+
+    const driver = new webdriver.Builder().
+      forBrowser("firefox").
+      setFirefoxOptions(fxOpts).
+      build();
+
+    // load web-ext
+    const webext = this.webext;
+    await driver.setContext(firefox.Context.CHROME);
+    webext.id = await driver.installAddon(webext.extensionPath);
+    webext.hostname = await driver.executeScript(`
+      const Cu = Components.utils;
+      const Services = ChromeUtils.import("resource://gre/modules/Services.jsm");
+      const { WebExtensionPolicy } = Cu.getGlobalForObject(Services);
+      return WebExtensionPolicy.getByID("${webext.id}").mozExtensionHostname;
+    `);
+    webext.baseURL = `moz-extension://${webext.hostname}`;
+    await driver.setContext(firefox.Context.CONTENT);
+    webext.driver = driver;
+
+    return this;
+  }
+
+  async stop() {
+    if (!this.running) {
+      return this;
+    }
+    const webext = this.webext;
+    const driver = webext.driver;
+
+    await driver.quit();
+    delete webext.id;
+    delete webext.hostname;
+    delete webext.baseURL;
+    delete webext.driver;
+
+    return this;
+  }
+}
+
+let _webext;
+export default async function prepare() {
+  if (!_webext) {
+    const manifest = PATH.resolve(__dirname, "../../dist/manifest.json");
+    const opts = {};
+    const webext = new WebExtensionDriver(manifest, opts);
+    _webext = await webext.initialize();
+  }
+
+  return _webext;
+}

--- a/test/integration/functional-test.js
+++ b/test/integration/functional-test.js
@@ -7,6 +7,7 @@
 import chai, { expect } from "chai";
 import chaiAsPromised from "chai-as-promised";
 import getWebExtension from "./driver";
+import createHelper from "./helper";
 
 chai.use(chaiAsPromised);
 
@@ -18,15 +19,7 @@ describe("Lockbox functional testing", () => {
   before(async () => {
     webext = await getWebExtension();
     await webext.start();
-    helper = {
-      async toolbar() {
-        const { driver, webdriver } = webext;
-
-        return driver.wait(webdriver.until.elementLocated(
-          webdriver.By.id(`${ident}-browser-action`)
-        ), 1000);
-      },
-    };
+    helper = createHelper(webext);
   });
 
   it("has a toolbar button", async () => {

--- a/test/integration/helper.js
+++ b/test/integration/helper.js
@@ -1,0 +1,31 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+function webext2chrome(id) {
+  return id.replace(/\.|@/g, "_");
+}
+export default function createHelper(webext) {
+  const { driver, webdriver } = webext;
+  const ident = webext2chrome(webext.id);
+
+  return {
+    async toolbar() {
+      return driver.wait(webdriver.until.elementLocated(
+        webdriver.By.id(`${ident}-browser-action`)
+      ), 1000);
+    },
+    async management() {
+      const url = webext.url("/list/manage.html");
+      const { driver, webdriver } = webext;
+      await driver.get(url);
+
+      return driver.wait(webdriver.until.elementLocated(
+        webdriver.By.css("main#content")
+      ), 1000);
+    },
+  };
+}
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,6 @@ const JSONTemplater = require("json-templater");
 const HTMLWebpackPlugin = require("html-webpack-plugin");
 const webpack = require("webpack");
 
-const pkg = require("./package.json");
 const NODE_ENV = (() => {
   if (process.env.NODE_ENV) {
     return process.env.NODE_ENV.toLowerCase();
@@ -19,6 +18,17 @@ const NODE_ENV = (() => {
     return process.env.NODE_SUGGESTED_ENV.toLowerCase();
   }
   return "development";
+})();
+
+const PKG = (() => {
+  const csp_scripts = (NODE_ENV === "test") ? "'unsafe-eval'" : "";
+  const csp_objects = (NODE_ENV === "test") ? "'unsafe-eval'" : "";
+  const pkg = require("./package.json");
+  return {
+    ...pkg,
+    csp_scripts,
+    csp_objects,
+  };
 })();
 
 const BABEL_OPTS = (() => {
@@ -108,7 +118,7 @@ module.exports = {
         to: "manifest.json",
         transform: (content, path) => {
           content = JSON.parse(content);
-          content = JSONTemplater.object(content, pkg);
+          content = JSONTemplater.object(content, PKG);
           content = JSON.stringify(content, null, "  ");
           return content;
         },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,13 +21,13 @@ const NODE_ENV = (() => {
 })();
 
 const PKG = (() => {
-  const csp_scripts = (NODE_ENV === "test") ? "'unsafe-eval'" : "";
-  const csp_objects = (NODE_ENV === "test") ? "'unsafe-eval'" : "";
+  const testing_csp_scripts = (NODE_ENV === "test") ? "'unsafe-eval'" : "";
+  const testing_csp_objects = (NODE_ENV === "test") ? "'unsafe-eval'" : "";
   const pkg = require("./package.json");
   return {
     ...pkg,
-    csp_scripts,
-    csp_objects,
+    testing_csp_scripts,
+    testing_csp_objects,
   };
 })();
 


### PR DESCRIPTION
Connected to #9

This refactor better uses the Selenium-based `webdriver` and the underlying `web-ext` API to run integration functional/accessibility tests using the same patterns the unit tests use.

This also adds support for running accessibility testing via `axe-webdriverjs` (to start, the management homepage).