### PR TITLE
HTML resource path bugfix for Windows builds

### DIFF
--- a/src/template.ejs
+++ b/src/template.ejs
@@ -5,13 +5,10 @@
 <html>
   <head>
     <meta charset="utf-8"/>
-    <% const path = require("path");
-       const dir = path.dirname(htmlWebpackPlugin.options.filename);
-       for (let css of htmlWebpackPlugin.files.css) {
-    %>
-    <link href="<%- path.relative(dir, css) %>" rel="stylesheet">
+    <% for (let css of htmlWebpackPlugin.files.css) { %>
+    <link href="<%- css %>" rel="stylesheet">
     <% } for (let js of htmlWebpackPlugin.files.js) { %>
-    <script src="<%- path.relative(dir, js) %>" defer></script>
+    <script src="<%- js %>" defer></script>
     <% } %>
     <link href="<%- htmlWebpackPlugin.options.icon %>" rel="shortcut icon" type="image/svg"/>
   </head>


### PR DESCRIPTION
Noticed errors in summoning the popup after a build on Windows.

Before this patch, thanks to accursed Windows path conventions, HTML output looked like so :
```html
<script src="..\..\list\manage.js" defer></script>
```
When I did a build under WSL Ubuntu, the script tag looked like so:
```html
<script src="../../list/manage.js" defer></script>
```
After, this patch it's like so from both environments:
```html
<script src="../list/manage.js" defer></script>
```
I don't think we need the extra `../` here - things seem to work without it. So, I just pulled out the relative path handling to get the build working from both Powershell and WSL bash.

(I might be missing something that required the relative path handling, though...)