### PR TITLE
Tweak Firefox code loader syntax to get integration tests running (#27)

### DIFF
--- a/test/integration/driver.js
+++ b/test/integration/driver.js
@@ -143,7 +143,7 @@ export class WebExtensionDriver {
     webext.id = await driver.installAddon(webext.extensionPath);
     webext.hostname = await driver.executeScript(`
       const Cu = Components.utils;
-      const Services = ChromeUtils.import("resource://gre/modules/Services.jsm");
+      ChromeUtils.defineModuleGetter(this, "Services", "resource://gre/modules/Services.jsm");
       const { WebExtensionPolicy } = Cu.getGlobalForObject(Services);
       return WebExtensionPolicy.getByID("${webext.id}").mozExtensionHostname;
     `);


### PR DESCRIPTION
I'm using Mac 10.13.6 and current Nightly.

With this change, the integration tests run and pass for me. Will be interesting to see if this change impacts CI.

Without this change, Nightly starts, but doesn't load any pages, and in the console, I see `JavascriptError: Error: resource://gre/modules/Services.jsm - Couldn't find target object for import`, followed by a cascade of "cannot read property foo of undefined" errors:

<details>

```

> lockbox@2.0.0-alpha integration /Users/jh/codez/github/mozilla-lockbox-lockbox-addon
> cross-env NODE_ENV=test mocha --require @babel/register --timeout 10000 test/integration/**/*-test.js



  accessibility
Building web extension from /Users/jh/codez/github/mozilla-lockbox-lockbox-addon/dist
Destination exists, overwriting: /Users/jh/codez/github/mozilla-lockbox-lockbox-addon/addons/lockbox-2.0.0-alpha.zip
Your web extension is ready: /Users/jh/codez/github/mozilla-lockbox-lockbox-addon/addons/lockbox-2.0.0-alpha.zip
    1) "before all" hook
    2) "after all" hook

  Lockbox functional testing
    3) has a toolbar button
    4) opens the doorhanger


  0 passing (2s)
  4 failing

  1) accessibility
       "before all" hook:
     JavascriptError: Error: resource://gre/modules/Services.jsm - Couldn't find target object for import.
      at Object.throwDecodedError (node_modules/selenium-webdriver/lib/error.js:550:15)
      at parseHttpResponse (node_modules/selenium-webdriver/lib/http.js:542:13)
      at Executor.execute (node_modules/selenium-webdriver/lib/http.js:468:26)
      at process._tickCallback (internal/process/next_tick.js:68:7)

  2) accessibility
       "after all" hook:
     TypeError: Cannot read property 'quit' of undefined
      at WebExtensionDriver.stop (test/integration/driver.js:185:18)
      at Context.after (test/integration/a11y-test.js:45:18)

  3) Lockbox functional testing
       has a toolbar button:
     TypeError: Cannot read property 'setContext' of undefined
      at WebExtensionDriver.inChrome (test/integration/driver.js:116:20)
      at Context.it (test/integration/functional-test.js:39:18)

  4) Lockbox functional testing
       opens the doorhanger:
     TypeError: Cannot read property 'setContext' of undefined
      at WebExtensionDriver.inChrome (test/integration/driver.js:116:20)
      at Context.it (test/integration/functional-test.js:45:18)



(node:3873) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'quit' of undefined
    at WebExtensionDriver.stop (/Users/jh/codez/github/mozilla-lockbox-lockbox-addon/test/integration/driver.js:185:18)
    at Context.after (/Users/jh/codez/github/mozilla-lockbox-lockbox-addon/test/integration/functional-test.js:56:12)
    at callFn (/Users/jh/codez/github/mozilla-lockbox-lockbox-addon/node_modules/mocha/lib/runnable.js:372:21)
    at Hook.Runnable.run (/Users/jh/codez/github/mozilla-lockbox-lockbox-addon/node_modules/mocha/lib/runnable.js:364:7)
    at next (/Users/jh/codez/github/mozilla-lockbox-lockbox-addon/node_modules/mocha/lib/runner.js:317:10)
    at Immediate.<anonymous> (/Users/jh/codez/github/mozilla-lockbox-lockbox-addon/node_modules/mocha/lib/runner.js:347:5)
    at runCallback (timers.js:694:18)
    at tryOnImmediate (timers.js:665:5)
    at processImmediate (timers.js:647:5)
(node:3873) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 4)
(node:3873) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
npm ERR! code ELIFECYCLE
npm ERR! errno 4
npm ERR! lockbox@2.0.0-alpha integration: `cross-env NODE_ENV=test mocha --require @babel/register --timeout 10000 test/integration/**/*-test.js`
npm ERR! Exit status 4
npm ERR! 
npm ERR! Failed at the lockbox@2.0.0-alpha integration script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/jh/.npm/_logs/2018-12-14T17_49_41_243Z-debug.log
```
</details>