### PR TITLE
Move clipboard operations into async background handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     }
   },
   "dependencies": {
-    "copy-to-clipboard": "^3.0.8",
     "fluent": "^0.8.1",
     "fluent-intl-polyfill": "^0.1.0",
     "fluent-langneg": "^0.1.0",

--- a/src/background/clipboard.js
+++ b/src/background/clipboard.js
@@ -1,0 +1,24 @@
+const CLIPBOARD_CLEAR_DELAY = 1 * 60 * 1000; // 1 minute
+
+let clearClipboardTimer = null;
+
+export async function copyToClipboard(field, toCopy, navigatorClipboard = navigator.clipboard) {
+  if (clearClipboardTimer) {
+    // Clear any existing timer before scheduling a new one.
+    window.clearTimeout(clearClipboardTimer);
+  }
+  await navigatorClipboard.writeText(toCopy);
+  clearClipboardTimer = window.setTimeout(
+    async () => {
+      clearClipboardTimer = null;
+      // Only clear the clipboard if it still holds the value set earlier.
+      const inClipboard = await navigatorClipboard.readText();
+      if (inClipboard === toCopy) {
+        navigatorClipboard.writeText("");
+      }
+    },
+    CLIPBOARD_CLEAR_DELAY
+  );
+}
+
+export default { copyToClipboard };

--- a/src/background/message-ports.js
+++ b/src/background/message-ports.js
@@ -6,6 +6,7 @@ import openDataStore from "./datastore";
 import { openView, closeView } from "./views";
 import { makeItemSummary } from "../common";
 import telemetry from "./telemetry";
+import clipboard from "./clipboard";
 
 const ports = new Set();
 
@@ -64,6 +65,9 @@ export default function initializeMessagePorts() {
       return {};
     case "telemetry_scalar":
         telemetry.scalarSet(message.name, message.value);
+        return {};
+    case "copied_field":
+        await clipboard.copyToClipboard(message.field, message.toCopy);
         return {};
     default:
       return null;

--- a/src/list/actions.js
+++ b/src/list/actions.js
@@ -19,7 +19,8 @@ export const REMOVE_ITEM_COMPLETED = Symbol("REMOVE_ITEM_COMPLETED");
 export const SELECT_ITEM_STARTING = Symbol("SELECT_ITEM_STARTING");
 export const SELECT_ITEM_COMPLETED = Symbol("SELECT_ITEM_COMPLETED");
 
-export const COPIED_FIELD = Symbol("COPIED_FIELD");
+export const COPIED_FIELD_STARTING = Symbol("COPIED_FIELD_STARTING");
+export const COPIED_FIELD_COMPLETED = Symbol("COPIED_FIELD_COMPLETED");
 
 export const START_NEW_ITEM = Symbol("START_NEW_ITEM");
 export const EDIT_CURRENT_ITEM = Symbol("EDIT_CURRENT_ITEM");
@@ -224,9 +225,30 @@ function selectItemCompleted(actionId, item) {
   };
 }
 
-export function copiedField(field) {
+export function copiedField(field, toCopy) {
+  return async (dispatch) => {
+    const actionId = nextActionId++;
+    dispatch(copiedFieldStarting(actionId));
+    await browser.runtime.sendMessage({
+      type: "copied_field",
+      field,
+      toCopy,
+    });
+    dispatch(copiedFieldCompleted(actionId, field));
+  };
+}
+
+function copiedFieldStarting(actionId) {
   return {
-    type: COPIED_FIELD,
+    type: COPIED_FIELD_STARTING,
+    actionId,
+  };
+}
+
+function copiedFieldCompleted(actionId, field) {
+  return {
+    type: COPIED_FIELD_COMPLETED,
+    actionId,
     field,
   };
 }

--- a/src/list/components/item-fields.js
+++ b/src/list/components/item-fields.js
@@ -50,7 +50,7 @@ export function ItemFields({fields, onCopy}) {
           </FieldText>
           <Localized id="item-fields-copy-username">
             <CopyToClipboardButton value={fields.username}
-                                   onCopy={() => onCopy("username")}/>
+                                   onCopy={toCopy => onCopy("username", toCopy)}/>
           </Localized>
         </div>
       </div>
@@ -64,7 +64,7 @@ export function ItemFields({fields, onCopy}) {
           </FieldText>
           <Localized id="item-fields-copy-password">
             <CopyToClipboardButton value={fields.password}
-                                   onCopy={() => onCopy("password")}/>
+                                   onCopy={toCopy => onCopy("password", toCopy)}/>
           </Localized>
         </div>
       </div>

--- a/src/list/components/item-summary.js
+++ b/src/list/components/item-summary.js
@@ -28,7 +28,7 @@ function ItemSummaryCopyButtons({id, username, onCopy}) {
         <CopyToClipboardButton className={styles.copyButton}
                                buttonClassName={styles.copyButtonInner}
                                value={username}
-                               onCopy={() => onCopy("username")}>
+                               onCopy={toCopy => onCopy("username", toCopy)}>
           cOPy uSERNAMe
         </CopyToClipboardButton>
       </Localized>
@@ -36,7 +36,7 @@ function ItemSummaryCopyButtons({id, username, onCopy}) {
         <CopyToClipboardButton className={styles.copyButton}
                                buttonClassName={styles.copyButtonInner}
                                value={getPassword}
-                               onCopy={() => onCopy("password")}>
+                               onCopy={toCopy => onCopy("password", toCopy)}>
           cOPy pASSWORd
         </CopyToClipboardButton>
       </Localized>

--- a/src/list/manage/containers/current-selection.js
+++ b/src/list/manage/containers/current-selection.js
@@ -46,7 +46,7 @@ const ConnectedItemDetails = connect(
     fields: flattenItem(ownProps.item),
   }),
   (dispatch, ownProps) => ({
-    onCopy: (field) => { dispatch(copiedField(field)); },
+    onCopy: (field, toCopy) => { dispatch(copiedField(field, toCopy)); },
     onEdit: () => { dispatch(editCurrentItem()); },
     onDelete: () => { dispatch(requestRemoveItem(ownProps.item.id)); },
   })

--- a/src/list/manage/telemetry.js
+++ b/src/list/manage/telemetry.js
@@ -41,7 +41,7 @@ export default (store) => (next) => (action) => {
                               {itemid: action.item.id});
       }
       break;
-    case actions.COPIED_FIELD:
+    case actions.COPIED_FIELD_COMPLETED:
       telemetry.recordEvent(`${action.field}Copied`, "manage");
       break;
     case actions.START_NEW_ITEM:

--- a/src/list/popup/containers/all-items-panel.js
+++ b/src/list/popup/containers/all-items-panel.js
@@ -24,6 +24,6 @@ export default connect(
   },
   (dispatch) => ({
     onClick: (id) => { dispatch(selectItem(id)); },
-    onCopy: (field) => { dispatch(copiedField(field)); },
+    onCopy: (field, toCopy) => { dispatch(copiedField(field, toCopy)); },
   }),
 )(ItemListPanel);

--- a/src/list/popup/containers/current-selection.js
+++ b/src/list/popup/containers/current-selection.js
@@ -16,7 +16,7 @@ const ConnectedItemDetailsPanel = connect(
     fields: flattenItem(ownProps.item),
   }),
   (dispatch) => ({
-    onCopy: (field) => { dispatch(copiedField(field)); },
+    onCopy: (field, toCopy) => { dispatch(copiedField(field, toCopy)); },
     onBack: () => { dispatch(selectItem(null)); },
   })
 )(ItemDetailsPanel);

--- a/src/list/popup/telemetry.js
+++ b/src/list/popup/telemetry.js
@@ -14,7 +14,7 @@ export default (store) => (next) => (action) => {
                               {itemid: action.item.id});
       }
       break;
-    case actions.COPIED_FIELD:
+    case actions.COPIED_FIELD_COMPLETED:
       telemetry.recordEvent(`${action.field}Copied`, "doorhanger");
       break;
     }

--- a/src/manifest.json.tpl
+++ b/src/manifest.json.tpl
@@ -40,6 +40,7 @@
 
   "permissions": [
     "tabs",
+    "clipboardRead",
     "clipboardWrite",
     "mozillaAddons",
     "telemetry"

--- a/src/widgets/copy-to-clipboard-button.js
+++ b/src/widgets/copy-to-clipboard-button.js
@@ -5,7 +5,6 @@
 import { Localized } from "fluent-react";
 import PropTypes from "prop-types";
 import React from "react";
-import copy from "copy-to-clipboard";
 
 import { classNames } from "../common";
 import Button from "./button";
@@ -47,12 +46,11 @@ export default class CopyToClipboardButton extends React.Component {
     const {value, timeout, onCopy} = this.props;
 
     const toCopy = value instanceof Function ? await value() : value;
-    copy(toCopy);
-
     this.setState({copied: true});
     setTimeout(() => this.setState({copied: false}), timeout);
+
     if (onCopy) {
-      onCopy();
+      onCopy(toCopy);
     }
   }
 

--- a/test/unit/background/clipboard-test.js
+++ b/test/unit/background/clipboard-test.js
@@ -1,0 +1,78 @@
+import chai, { expect } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import sinon from "sinon";
+import sinonChai from "sinon-chai";
+
+import { copyToClipboard } from "src/background/clipboard";
+
+chai.use(chaiAsPromised);
+chai.use(sinonChai);
+
+describe("background > copyToClipboard", () => {
+
+  let clipboardText, mockClipboard, realSetTimeout, realClearTimeout;
+
+  beforeEach(() => {
+    realSetTimeout = window.setTimeout;
+    realClearTimeout = window.clearTimeout;
+    window.setTimeout = sinon.spy(() => Date.now() + Math.random());
+    window.clearTimeout = sinon.spy();
+
+    clipboardText = "";
+    mockClipboard = {
+      readText: sinon.spy(async () => clipboardText),
+      writeText: sinon.spy(async (newText) => clipboardText = newText),
+    };
+  });
+
+  afterEach(() => {
+    window.setTimeout = realSetTimeout;
+    window.clearTimeout = realClearTimeout;
+  });
+
+  const subject = (text = "textToCopy") =>
+    copyToClipboard("testField", text, mockClipboard);
+
+  it("copies to clipboard", async () => {
+    await subject();
+
+    expect(mockClipboard.writeText.firstCall.args)
+      .to.deep.equal(["textToCopy"]);
+  });
+
+  it("clears the clipboard after a delay", async () => {
+    await subject();
+
+    expect(window.setTimeout.callCount).to.equal(1);
+    expect(window.setTimeout.firstCall.args[1]).to.equal(60000);
+
+    const clearFn = window.setTimeout.firstCall.args[0];
+    await clearFn();
+
+    expect(mockClipboard.readText.callCount).to.equal(1);
+    expect(mockClipboard.writeText.callCount).to.equal(2);
+    expect(mockClipboard.writeText.lastCall.args).to.deep.equal([""]);
+  });
+
+  it("cancels the previous clearing delay on subsequent copy", async () => {
+    await subject();
+    expect(window.setTimeout.callCount).to.equal(1);
+    expect(window.clearTimeout.callCount).to.equal(0);
+
+    await subject("new value");
+    expect(window.setTimeout.callCount).to.equal(2);
+    expect(window.clearTimeout.callCount).to.equal(1);
+  });
+
+  it("skips clearing the clipboard if contents have changed", async () => {
+    await subject();
+
+    clipboardText = "Something completely different";
+
+    const clearFn = window.setTimeout.firstCall.args[0];
+    await clearFn();
+
+    expect(mockClipboard.readText.callCount).to.equal(1);
+    expect(mockClipboard.writeText.callCount).to.equal(1);
+  });
+});

--- a/test/unit/background/message-ports-test.js
+++ b/test/unit/background/message-ports-test.js
@@ -11,6 +11,7 @@ import "test/unit/mocks/browser";
 import openDataStore from "src/background/datastore";
 import initializeMessagePorts from "src/background/message-ports";
 import telemetry from "src/background/telemetry";
+import clipboard from "src/background/clipboard";
 
 chai.use(chaiAsPromised);
 chai.use(sinonChai);
@@ -170,6 +171,22 @@ describe("background > message ports", () => {
     expect(spied.called).to.be.true;
     expect(spied).to.have.been.calledWith("method", "object",
                                           {extra: "value"});
+    spied.restore();
+  });
+
+  it("handles copied_field", async () => {
+    const spied = sinon.stub(clipboard, "copyToClipboard").resolves(true);
+    const result = await browser.runtime.sendMessage({
+      type: "copied_field",
+      field: "testField",
+      toCopy: "textToCopy",
+    });
+
+    expect(result).to.deep.equal({});
+    expect(spied.called).to.be.true;
+    expect(spied.lastCall.args[0]).to.equal("testField");
+    expect(spied.lastCall.args[1]).to.equal("textToCopy");
+
     spied.restore();
   });
 

--- a/test/unit/list/actions-test.js
+++ b/test/unit/list/actions-test.js
@@ -279,10 +279,22 @@ describe("list > actions", () => {
     ]);
   });
 
-  it("copiedField() dispatched", () => {
-    store.dispatch(actions.copiedField("field"));
-    expect(store.getActions()).to.deep.equal([
-      { type: actions.COPIED_FIELD,
+  it("copiedField() dispatched", async () => {
+    browser.runtime.onMessage.addListener((msg) => {
+      if (msg.type === "copied_field") {
+        // item: {...item, field: "field", toCopy: "toCopy"}};
+        return {};
+      }
+      return null;
+    });
+
+    await store.dispatch(actions.copiedField("field", "toCopy"));
+    const dispatched = store.getActions();
+    expect(dispatched).to.deep.equal([
+      { type: actions.COPIED_FIELD_STARTING,
+        actionId: dispatched[0].actionId },
+      { type: actions.COPIED_FIELD_COMPLETED,
+        actionId: dispatched[0].actionId,
         field: "field" },
     ]);
   });

--- a/test/unit/list/components/item-summary-test.js
+++ b/test/unit/list/components/item-summary-test.js
@@ -10,8 +10,6 @@ import React from "react";
 import sinon from "sinon";
 import sinonChai from "sinon-chai";
 
-import CopyToClipboardButton from
-       "src/widgets/copy-to-clipboard-button";
 import mountWithL10n from "test/unit/mocks/l10n";
 import { NEW_ITEM_ID } from "src/list/common";
 import ItemSummary from "src/list/components/item-summary";
@@ -56,12 +54,10 @@ describe("list > components > <ItemSummary/>", () => {
   });
 
   describe("verbose", () => {
-    let wrapper, mockCopy, onCopy;
+    let wrapper, onCopy;
 
     beforeEach(() => {
-      mockCopy = sinon.spy();
       onCopy = sinon.spy();
-      CopyToClipboardButton.__Rewire__("copy", mockCopy);
 
       wrapper = mountWithL10n(
         <ItemSummary verbose id="1" title="title"
@@ -75,7 +71,6 @@ describe("list > components > <ItemSummary/>", () => {
 
     afterEach(() => {
       browser.runtime.onMessage.mockClearListener();
-      CopyToClipboardButton.__ResetDependency__("copy");
     });
 
     it("render item verbosely", () => {
@@ -90,15 +85,13 @@ describe("list > components > <ItemSummary/>", () => {
 
     it("copy username", () => {
       wrapper.find("button").at(0).simulate("click");
-      expect(mockCopy).to.have.been.calledWith("whudson@uscmc.mil");
-      expect(onCopy).to.have.been.calledWith("username");
+      expect(onCopy).to.have.been.calledWith("username", "whudson@uscmc.mil");
     });
 
     it("copy password", async () => {
       wrapper.find("button").at(1).simulate("click");
-      await waitUntil(() => mockCopy.callCount === 1);
-      expect(mockCopy).to.have.been.calledWith("g4m3_0v3r");
-      expect(onCopy).to.have.been.calledWith("password");
+      await waitUntil(() => onCopy.callCount === 1);
+      expect(onCopy).to.have.been.calledWith("password", "g4m3_0v3r");
     });
   });
 });

--- a/test/unit/list/manage/telemetry-test.js
+++ b/test/unit/list/manage/telemetry-test.js
@@ -131,7 +131,7 @@ describe("list > manage > telemetryLogger middleware", () => {
 
   it("record telemetry for a copied field", async () => {
     telemetryLogger(store)(next)({
-      type: actions.COPIED_FIELD,
+      type: actions.COPIED_FIELD_COMPLETED,
       field: "username",
     });
     expect(listener).to.have.been.calledWith({

--- a/test/unit/list/popup/telemetry-test.js
+++ b/test/unit/list/popup/telemetry-test.js
@@ -6,7 +6,7 @@ import chai, { expect } from "chai";
 import sinon from "sinon";
 import sinonChai from "sinon-chai";
 
-import { SELECT_ITEM_COMPLETED, COPIED_FIELD } from "src/list/actions";
+import { SELECT_ITEM_COMPLETED, COPIED_FIELD_COMPLETED } from "src/list/actions";
 import telemetryLogger from "src/list/popup/telemetry";
 
 chai.use(sinonChai);
@@ -57,7 +57,7 @@ describe("list > popup > telemetryLogger middleware", () => {
 
   it("record telemetry for a copied field", async () => {
     telemetryLogger(store)(next)({
-      type: COPIED_FIELD,
+      type: COPIED_FIELD_COMPLETED,
       field: "username",
     });
     expect(listener).to.have.been.calledWith({

--- a/test/unit/widgets/copy-to-clipboard-button-test.js
+++ b/test/unit/widgets/copy-to-clipboard-button-test.js
@@ -19,17 +19,6 @@ chai.use(sinonChai);
 chai.use(chaiFocus);
 
 describe("widgets > <CopyToClipboardButton/>", () => {
-  let mockCopy;
-
-  beforeEach(() => {
-    mockCopy = sinon.spy();
-    CopyToClipboardButton.__Rewire__("copy", mockCopy);
-  });
-
-  afterEach(() => {
-    CopyToClipboardButton.__ResetDependency__("copy");
-  });
-
   it("render button", () => {
     const wrapper = mountWithL10n(<CopyToClipboardButton value="hi there"/>);
     expect(wrapper.find("button")).to.have.text("cOPy");
@@ -59,10 +48,9 @@ describe("widgets > <CopyToClipboardButton/>", () => {
     expect(wrapper.find("button")).to.have.text("custom label");
   });
 
-  it("copy fired", () => {
+  it("copy feedback displayed", () => {
     const wrapper = mountWithL10n(<CopyToClipboardButton value="hi there"/>);
     wrapper.find("button").simulate("click");
-    expect(mockCopy).to.have.callCount(1);
     expect(wrapper.find(Stack).prop("selectedIndex")).to.equal(1);
   });
 
@@ -72,7 +60,6 @@ describe("widgets > <CopyToClipboardButton/>", () => {
       <CopyToClipboardButton value="hi there" onCopy={onCopy}/>
     );
     wrapper.find("button").simulate("click");
-    expect(mockCopy).to.have.callCount(1);
     expect(onCopy).to.have.callCount(1);
   });
 
@@ -84,7 +71,6 @@ describe("widgets > <CopyToClipboardButton/>", () => {
 
     const wrapper = mountWithL10n(<CopyToClipboardButton value="hi there"/>);
     wrapper.find("button").simulate("click");
-    expect(mockCopy).to.have.callCount(1);
     expect(wrapper.find(Stack).prop("selectedIndex")).to.equal(0);
 
     window.setTimeout = realSetTimeout;


### PR DESCRIPTION
- CopyToClipboardButton no longer does a clipboard operation, just
  displays "copied" feedback and passes resolved toCopy to onCopy

- Every onCopy handler now accepts toCopy to carry the clipboard value
  into the copiedField() action creator

- Tweak copiedField() action creator to dispatch COPIED_FIELD_STARTING and
  COPIED_FIELD_COMPLETED tracking async message to background script

- Add clipboard module to background script along with "copied_field"
  message type

- Add clipboardRead permission - so that we can check that clipboard
  content has not changed since we wrote to it before clearing it

- Drop copy-to-clipboard dependency

- Updates to tests

Fixes #7