### PR TITLE
Logins API

### DIFF
--- a/src/experiments/logins/api.js
+++ b/src/experiments/logins/api.js
@@ -49,7 +49,7 @@ this.logins = class extends ExtensionAPI {
           },
           add(loginInfo) {
             if (getLogin(loginInfo.guid)) {
-              throw new ExtensionError(`Add failed: Login already exists with GUID ${loginInfo.guid}`);
+              throw new ExtensionError(`Add failed: Login already exists with ID ${loginInfo.guid}`);
             }
             try {
               const login = LoginHelper.vanillaObjectToLogin(loginInfo);
@@ -63,7 +63,7 @@ this.logins = class extends ExtensionAPI {
           update(loginInfo) {
             const login = getLogin(loginInfo.guid);
             if (!login) {
-              throw new ExtensionError(`Update failed: Login not found with GUID ${loginInfo.guid}`);
+              throw new ExtensionError(`Update failed: Login not found with ID ${loginInfo.guid}`);
             }
             const loginAndMetaData = LoginHelper.newPropertyBag(loginInfo);
             Services.logins.modifyLogin(login, loginAndMetaData);
@@ -73,7 +73,7 @@ this.logins = class extends ExtensionAPI {
           remove(id) {
             const login = getLogin(id);
             if (!login) {
-              throw new ExtensionError(`Remove failed: Login not found with GUID ${id}`);
+              throw new ExtensionError(`Remove failed: Login not found with ID ${id}`);
             }
             try {
               Services.logins.removeLogin(LoginHelper.vanillaObjectToLogin(login));

--- a/src/experiments/logins/api.js
+++ b/src/experiments/logins/api.js
@@ -86,7 +86,7 @@ this.logins = class extends ExtensionAPI {
                 timeLastUsed: Date.now(),
               });
               Services.logins.modifyLogin(login, updates);
-              const updatedLogin = getLogin(loginInfo.guid);
+              const updatedLogin = getLogin(login.guid);
               return updatedLogin;
             } catch (ex) {
               throw new ExtensionError(ex);

--- a/src/experiments/logins/api.js
+++ b/src/experiments/logins/api.js
@@ -1,0 +1,164 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/* globals AppConstants, browser, Components, CustomizableUI, dispatcher,
+   ExtensionCommon, ExtensionAPI, Services, XPCOMUtils */
+
+"use strict";
+
+ChromeUtils.defineModuleGetter(this, "ExtensionUtils",
+                               "resource://gre/modules/ExtensionUtils.jsm");
+ChromeUtils.defineModuleGetter(this, "LoginHelper",
+                               "resource://gre/modules/LoginHelper.jsm");
+ChromeUtils.defineModuleGetter(this, "Services",
+                               "resource://gre/modules/Services.jsm");
+
+const { ExtensionError } = ExtensionUtils;
+
+const getLogins = () => {
+  const logins = Services.logins.
+    getAllLogins().
+    filter((l) => !(l.hostname || "").startsWith("chrome://")).
+    map(LoginHelper.loginToVanillaObject);
+  return logins;
+};
+
+const getLogin = (id) => {
+  const login = getLogins().
+    filter(l => l.guid === id)[0];
+  return login || null;
+};
+
+this.logins = class extends ExtensionAPI {
+  getAPI(context) {
+    const EventManager = ExtensionCommon.EventManager;
+    return {
+      experiments: {
+        logins: {
+          // See schema.json for function documentation.
+          getAll() {
+            const logins = getLogins();
+            return logins;
+          },
+          get(id) {
+            const login = getLogin(id);
+            return login;
+          },
+          // TODO: should this be called create(), or should the event name be changed to onAdded?
+          add(loginInfo) {
+            if (getLogin(loginInfo.guid)) {
+              throw new ExtensionError(`Add failed: Login already exists with GUID ${loginInfo.guid}`);
+            }
+            try {
+              const login = LoginHelper.vanillaObjectToLogin(loginInfo);
+              Services.logins.addLogin(login);
+            } catch (ex) {
+              throw new ExtensionError(ex);
+            }
+            const createdLogin = getLogin(loginInfo.guid);
+            return createdLogin;
+          },
+          update(loginInfo) {
+            const login = getLogin(loginInfo.guid);
+            if (!login) {
+              throw new ExtensionError(`Update failed: Login not found with GUID ${loginInfo.guid}`);
+            }
+            const loginAndMetaData = LoginHelper.newPropertyBag(loginInfo);
+            Services.logins.modifyLogin(login, loginAndMetaData);
+            const updatedLogin = getLogin(loginInfo.guid);
+            return updatedLogin;
+          },
+          remove(id) {
+            const login = getLogin(id);
+            if (!login) {
+              throw new ExtensionError(`Remove failed: Login not found with GUID ${id}`);
+            }
+            try {
+              Services.logins.removeLogin(LoginHelper.vanillaObjectToLogin(login));
+            } catch (ex) {
+              throw new ExtensionError(ex);
+            }
+          },
+          onCreated: new EventManager(context, "logins.onCreated", fire => {
+            const callback = (value) => {
+              fire.async(value);
+            };
+            const observer = {
+              observe: (subject, topic, type) => {
+                if (type !== "addLogin") {
+                  return;
+                }
+                subject.QueryInterface(Ci.nsILoginMetaInfo).QueryInterface(Ci.nsILoginInfo);
+                const login = LoginHelper.loginToVanillaObject(subject);
+                callback({ login });
+              },
+            };
+            Services.obs.addObserver(observer, "passwordmgr-storage-changed");
+            return () => {
+              Services.obs.removeObserver(observer, "passwordmgr-storage-changed");
+            };
+          }).api(),
+          onUpdated: new EventManager(context, "logins.onUpdated", fire => {
+            const callback = (value) => {
+              fire.async(value);
+            };
+            const observer = {
+              observe: (subject, topic, type) => {
+                if (type !== "modifyLogin") {
+                  return;
+                }
+                subject.QueryInterface(Ci.nsIArrayExtensions);
+                const newLogin = subject.GetElementAt(1);
+                const login = LoginHelper.loginToVanillaObject(newLogin);
+                callback({ login });
+              },
+            };
+            Services.obs.addObserver(observer, "passwordmgr-storage-changed");
+            return () => {
+              Services.obs.removeObserver(observer, "passwordmgr-storage-changed");
+            };
+          }).api(),
+          onRemoved: new EventManager(context, "logins.onRemoved", fire => {
+            const callback = (value) => {
+              fire.async(value);
+            };
+            const observer = {
+              observe: (subject, topic, type) => {
+                if (type !== "removeLogin") {
+                  return;
+                }
+                subject.QueryInterface(Ci.nsILoginMetaInfo).QueryInterface(Ci.nsILoginInfo);
+                const login = LoginHelper.loginToVanillaObject(subject);
+                callback({ login });
+              },
+            };
+            Services.obs.addObserver(observer, "passwordmgr-storage-changed");
+            return () => {
+              Services.obs.removeObserver(observer, "passwordmgr-storage-changed");
+            };
+          }).api(),
+          onAllRemoved: new EventManager(context, "logins.onAllRemoved", fire => {
+            const callback = (value) => {
+              fire.async(value);
+            };
+            const observer = {
+              observe: (subject, topic, type) => {
+                if (type !== "removeAllLogins") {
+                  return;
+                }
+                callback();
+              },
+            };
+            Services.obs.addObserver(observer, "passwordmgr-storage-changed");
+            return () => {
+              Services.obs.removeObserver(observer, "passwordmgr-storage-changed");
+            };
+          }).api(),
+        },
+      },
+    };
+  }
+};

--- a/src/experiments/logins/api.js
+++ b/src/experiments/logins/api.js
@@ -54,21 +54,25 @@ this.logins = class extends ExtensionAPI {
             try {
               const login = LoginHelper.vanillaObjectToLogin(loginInfo);
               Services.logins.addLogin(login);
+              const createdLogin = getLogin(loginInfo.guid);
+              return createdLogin;
             } catch (ex) {
               throw new ExtensionError(ex);
             }
-            const createdLogin = getLogin(loginInfo.guid);
-            return createdLogin;
           },
           update(loginInfo) {
             const login = getLogin(loginInfo.guid);
             if (!login) {
               throw new ExtensionError(`Update failed: Login not found with ID ${loginInfo.guid}`);
             }
-            const loginAndMetaData = LoginHelper.newPropertyBag(loginInfo);
-            Services.logins.modifyLogin(login, loginAndMetaData);
-            const updatedLogin = getLogin(loginInfo.guid);
-            return updatedLogin;
+            try {
+              const loginAndMetaData = LoginHelper.newPropertyBag(loginInfo);
+              Services.logins.modifyLogin(login, loginAndMetaData);
+              const updatedLogin = getLogin(loginInfo.guid);
+              return updatedLogin;
+            } catch (ex) {
+              throw new ExtensionError(ex);
+            }
           },
           touch(id) {
             const login = getLogin(id);
@@ -82,6 +86,8 @@ this.logins = class extends ExtensionAPI {
                 timeLastUsed: Date.now(),
               });
               Services.logins.modifyLogin(login, updates);
+              const updatedLogin = getLogin(loginInfo.guid);
+              return updatedLogin;
             } catch (ex) {
               throw new ExtensionError(ex);
             }

--- a/src/experiments/logins/api.js
+++ b/src/experiments/logins/api.js
@@ -47,7 +47,6 @@ this.logins = class extends ExtensionAPI {
             const login = getLogin(id);
             return login;
           },
-          // TODO: should this be called create(), or should the event name be changed to onAdded?
           add(loginInfo) {
             if (getLogin(loginInfo.guid)) {
               throw new ExtensionError(`Add failed: Login already exists with GUID ${loginInfo.guid}`);
@@ -82,7 +81,7 @@ this.logins = class extends ExtensionAPI {
               throw new ExtensionError(ex);
             }
           },
-          onCreated: new EventManager(context, "logins.onCreated", fire => {
+          onAdded: new EventManager(context, "logins.onAdded", fire => {
             const callback = (value) => {
               fire.async(value);
             };

--- a/src/experiments/logins/api.js
+++ b/src/experiments/logins/api.js
@@ -70,6 +70,22 @@ this.logins = class extends ExtensionAPI {
             const updatedLogin = getLogin(loginInfo.guid);
             return updatedLogin;
           },
+          touch(id) {
+            const login = getLogin(id);
+            if (!login) {
+              throw new ExtensionError(`Touch failed: Login not found with ID ${id}`);
+            }
+            try {
+              const updates = LoginHelper.newPropertyBag({
+                guid: login.guid,
+                timesUsedIncrement: 1,
+                timeLastUsed: Date.now(),
+              });
+              Services.logins.modifyLogin(login, updates);
+            } catch (ex) {
+              throw new ExtensionError(ex);
+            }
+          },
           remove(id) {
             const login = getLogin(id);
             if (!login) {

--- a/src/experiments/logins/schema.json
+++ b/src/experiments/logins/schema.json
@@ -240,6 +240,17 @@
         }]
       },
       {
+        "name": "touch",
+        "type": "function",
+        "description": "Convenience method to update the last used time, and increment the used count, for the given Login. Returns a Promise that resolves if the Login was successfully updated. Rejects the returned Promise if the Login was not found.",
+        "async": true,
+        "parameters": [{
+          "name": "id",
+          "type": "string",
+          "description": "The ID of the Login to be updated."
+        }]
+      },
+      {
         "name": "remove",
         "type": "function",
         "description": "Removes the Login identified by the Login ID. Returns a Promise that resolves if the Login is successfully removed. Rejects the returned Promise if the Login was not found.",

--- a/src/experiments/logins/schema.json
+++ b/src/experiments/logins/schema.json
@@ -3,19 +3,14 @@
     "namespace": "experiments.logins",
     "description": "Firefox Lockbox internal API for accessing logins",
     "types": [{
-      "id": "Mozilla-GUID",
-      "type": "string",
-      "description": "A GUID as created by nsIUUIDGenerator: a randomly-generated UUID, wrapped in curly braces. For example, '{d4e1a1f6-5ea0-40ee-bff5-da57982f21cf}'.",
-      "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$"
-    }, {
       "id": "Login",
       "type": "object",
       "description": "Represents a login, with the union of properties defined in either nsILoginInfo or nsILoginMetaData.",
       "properties": {
         "guid": {
-          "$ref": "Mozilla-GUID",
+          "type": "string",
           "optional": false,
-          "description": "The Mozilla-GUID to uniquely identify the login. This can be any arbitrary string, but a format as created by nsIUUIDGenerator is recommended. For example, '{d4e1a1f6-5ea0-40ee-bff5-da57982f21cf}'. (From nsILoginMetaInfo.idl)"
+          "description": "The unique identifier for the login. This can be any arbitrary string, but a format as created by nsIUUIDGenerator is recommended. For example, '{d4e1a1f6-5ea0-40ee-bff5-da57982f21cf}'. (From nsILoginMetaInfo.idl)"
         },
         "hostname": {
           "type": "string",
@@ -78,10 +73,10 @@
     }, {
       "id": "LoginUpdate",
       "type": "object",
-      "description": "Represents a Login with all fields optional except the Mozilla-GUID, so that updates only need to include updated fields. Note the additional convenience property 'timesUsedIncrement', which can be used to increment the 'timesUsed' value without having to check its existing value.",
+      "description": "Represents a Login with all fields optional except the ID, so that updates only need to include updated fields. Note the additional convenience property 'timesUsedIncrement', which can be used to increment the 'timesUsed' value without having to check its existing value.",
       "properties": {
         "guid": {
-          "$ref": "Mozilla-GUID",
+          "type": "string",
           "optional": false,
           "description": "See Login type for description."
         },
@@ -214,18 +209,18 @@
       {
         "name": "get",
         "type": "function",
-        "description": "Gets a Login, given a Mozilla-GUID. Returns a Promise that resolves to the Login, if the Mozilla-GUID was found, or null, if it was not found.",
+        "description": "Gets a Login, given a Login ID. Returns a Promise that resolves to the Login, if the Login ID was found, or null, if it was not found.",
         "async": true,
         "parameters": [{
           "name": "id",
-          "$ref": "Mozilla-GUID",
-          "description": "The Mozilla-GUID of the Login to retrieve."
+          "type": "string",
+          "description": "The ID of the Login to retrieve."
         }]
       },
       {
         "name": "add",
         "type": "function",
-        "description": "Creates a new Login. Returns a Promise that resolves to the newly-created Login, if successful. Rejects the returned Promise if the Mozilla-GUID already exists, or if required fields are missing or malformed.",
+        "description": "Creates a new Login. Returns a Promise that resolves to the newly-created Login, if successful. Rejects the returned Promise if the Login ID already exists, or if required fields are missing or malformed.",
         "async": true,
         "parameters": [{
           "name": "loginInfo",
@@ -236,23 +231,23 @@
       {
         "name": "update",
         "type": "function",
-        "description": "Updates an existing Login (either nsILoginInfo or nsILoginMetaData fields). Requires passing the Mozilla-GUID and any fields to be updated. Note: use 'timesUsedIncrement' to increment 'timesUsed', rather than getting and checking the existing value first. Returns a Promise that resolves to the updated Login, if successful. Rejects the returned Promise if the Mozilla-GUID was not found, or if any fields were malformed.",
+        "description": "Updates an existing Login (either nsILoginInfo or nsILoginMetaData fields). Requires passing the Login ID and any fields to be updated. Note: use 'timesUsedIncrement' to increment 'timesUsed', rather than getting and checking the existing value first. Returns a Promise that resolves to the updated Login, if successful. Rejects the returned Promise if the Login ID was not found, or if any fields were malformed.",
         "async": true,
         "parameters": [{
           "name": "loginInfo",
           "$ref": "LoginUpdate",
-          "description": "Object containing Mozilla-GUID and any fields to be updated."
+          "description": "Object containing Login ID and any fields to be updated."
         }]
       },
       {
         "name": "remove",
         "type": "function",
-        "description": "Removes the Login identified by the Mozilla-GUID. Returns a Promise that resolves if the Login is successfully removed. Rejects the returned Promise if the Login was not found.",
+        "description": "Removes the Login identified by the Login ID. Returns a Promise that resolves if the Login is successfully removed. Rejects the returned Promise if the Login was not found.",
         "async": true,
         "parameters": [{
           "name": "id",
-          "$ref": "Mozilla-GUID",
-          "description": "The Mozilla-GUID of the Login to be removed."
+          "type": "string",
+          "description": "The ID of the Login to be removed."
         }]
       }
     ]

--- a/src/experiments/logins/schema.json
+++ b/src/experiments/logins/schema.json
@@ -236,7 +236,7 @@
         "parameters": [{
           "name": "loginInfo",
           "$ref": "LoginUpdate",
-          "description": "Object containing Login ID and any fields to be updated."
+          "description": "Object containing Login ID and any nsILoginInfo or nsILoginMetaInfo fields to be updated."
         }]
       },
       {

--- a/src/experiments/logins/schema.json
+++ b/src/experiments/logins/schema.json
@@ -150,9 +150,9 @@
     }],
     "events": [
       {
-        "name": "onCreated",
+        "name": "onAdded",
         "type": "function",
-        "description": "Fired when a Login is created. Event includes the newly-created Login.",
+        "description": "Fired when a Login is added. Event includes the newly-created Login.",
         "parameters": [
           {
             "type": "object",

--- a/src/experiments/logins/schema.json
+++ b/src/experiments/logins/schema.json
@@ -5,7 +5,7 @@
     "types": [{
       "id": "Login",
       "type": "object",
-      "description": "Represents a login, with the union of properties defined in either nsILoginInfo or nsILoginMetaData.",
+      "description": "Represents a login, with the union of properties defined in either nsILoginInfo or nsILoginMetaInfo.",
       "properties": {
         "guid": {
           "type": "string",
@@ -231,7 +231,7 @@
       {
         "name": "update",
         "type": "function",
-        "description": "Updates an existing Login (either nsILoginInfo or nsILoginMetaData fields). Requires passing the Login ID and any fields to be updated. Note: use 'timesUsedIncrement' to increment 'timesUsed', rather than getting and checking the existing value first. Returns a Promise that resolves to the updated Login, if successful. Rejects the returned Promise if the Login ID was not found, or if any fields were malformed.",
+        "description": "Updates an existing Login (either nsILoginInfo or nsILoginMetaInfo fields). Requires passing the Login ID and any fields to be updated. Note: use 'timesUsedIncrement' to increment 'timesUsed', rather than getting and checking the existing value first. Returns a Promise that resolves to the updated Login, if successful. Rejects the returned Promise if the Login ID was not found, or if any fields were malformed.",
         "async": true,
         "parameters": [{
           "name": "loginInfo",

--- a/src/experiments/logins/schema.json
+++ b/src/experiments/logins/schema.json
@@ -1,0 +1,260 @@
+[
+  {
+    "namespace": "experiments.logins",
+    "description": "Firefox Lockbox internal API for accessing logins",
+    "types": [{
+      "id": "Mozilla-GUID",
+      "type": "string",
+      "description": "A GUID as created by nsIUUIDGenerator: a randomly-generated UUID, wrapped in curly braces. For example, '{d4e1a1f6-5ea0-40ee-bff5-da57982f21cf}'.",
+      "pattern": "^\\{[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\}$"
+    }, {
+      "id": "Login",
+      "type": "object",
+      "description": "Represents a login, with the union of properties defined in either nsILoginInfo or nsILoginMetaData.",
+      "properties": {
+        "guid": {
+          "$ref": "Mozilla-GUID",
+          "optional": false,
+          "description": "The Mozilla-GUID to uniquely identify the login. This can be any arbitrary string, but a format as created by nsIUUIDGenerator is recommended. For example, '{d4e1a1f6-5ea0-40ee-bff5-da57982f21cf}'. (From nsILoginMetaInfo.idl)"
+        },
+        "hostname": {
+          "type": "string",
+          "optional": false,
+          "description": "The hostname the login applies to. The hostname should be formatted as a URL. For example, 'https://site.com', 'http://site.com:1234', 'ftp://ftp.site.com'. (From nsILoginInfo.idl)"
+        },
+        "formSubmitURL": {
+          "type": "string",
+          "optional": true,
+          "default": null,
+          "description": "The URL a form-based login was submitted to. For logins obtained from HTML forms, this field is the |action| attribute from the |form| element, with the path removed. For example 'http://www.site.com'. Forms with no |action| attribute default to submitting to their origin URL, so we store that. For logins obtained from a HTTP or FTP protocol authentication, this field is NULL. (From nsILoginInfo.idl)"
+        },
+        "httpRealm": {
+          "type": "any",
+          "optional": false,
+          "default": null,
+          "description": "The HTTP Realm a login was requested for. When an HTTP server sends a 401 result, the WWW-Authenticate header includes a realm to identify the 'protection space.' See RFC2617. If the response sent has a missing or blank realm, the hostname is used instead. For logins obtained from HTML forms, this field is NULL. (From nsILoginInfo.idl) Note that a Login cannot have both a non-null httpRealm and a formSubmitURL."
+        },
+        "password": {
+          "type": "string",
+          "optional": false,
+          "description": "The password for the login. (From nsILoginInfo.idl)"
+        },
+        "passwordField": {
+          "type": "string",
+          "optional": false,
+          "description": "The |name| attribute for the password input field. For logins obtained from a HTTP or FTP protocol authentication, this field is an empty string. (From nsILoginInfo.idl)"
+        },
+        "timeCreated": {
+          "type": "number",
+          "optional": false,
+          "description": "The time, in Unix Epoch milliseconds, when the login was first created. (From nsILoginMetaInfo.idl)"
+        },
+        "timeLastUsed": {
+          "type": "number",
+          "optional": false,
+          "description": "The time, in Unix Epoch milliseconds, when the login was last submitted in a form or used to begin an HTTP auth session. (From nsILoginMetaInfo.idl)"
+        },
+        "timePasswordChanged": {
+          "type": "number",
+          "optional": false,
+          "description": "The time, in Unix Epoch milliseconds, when the login was last modified. Contrary to what the name may suggest, this attribute takes into account not only the password but also the username attribute. (From nsILoginMetaInfo.idl)"
+        },
+        "timesUsed": {
+          "type": "number",
+          "optional": false,
+          "description": "The number of times the login was submitted in a form or used to begin an HTTP auth session. (From nsILoginMetaInfo.idl)"
+        },
+        "username": {
+          "type": "string",
+          "optional": false,
+          "description": "The username for the login. (From nsILoginInfo.idl)"
+        },
+        "usernameField": {
+          "type": "string",
+          "optional": false,
+          "description": "The |name| attribute for the username input field. For logins obtained from a HTTP or FTP protocol authentication, this field is an empty string. (From nsILoginInfo.idl)"
+        }
+      }
+    }, {
+      "id": "LoginUpdate",
+      "type": "object",
+      "description": "Represents a Login with all fields optional except the Mozilla-GUID, so that updates only need to include updated fields. Note the additional convenience property 'timesUsedIncrement', which can be used to increment the 'timesUsed' value without having to check its existing value.",
+      "properties": {
+        "guid": {
+          "$ref": "Mozilla-GUID",
+          "optional": false,
+          "description": "See Login type for description."
+        },
+        "hostname": {
+          "type": "string",
+          "optional": true,
+          "description": "See Login type for description."
+        },
+        "formSubmitURL": {
+          "type": "string",
+          "optional": true,
+          "default": null,
+          "description": "See Login type for description."
+        },
+        "httpRealm": {
+          "type": "any",
+          "optional": true,
+          "description": "See Login type for description."
+        },
+        "password": {
+          "type": "string",
+          "optional": true,
+          "description": "See Login type for description."
+        },
+        "passwordField": {
+          "type": "string",
+          "optional": true,
+          "description": "See Login type for description."
+        },
+        "timeCreated": {
+          "type": "number",
+          "optional": true,
+          "description": "See Login type for description."
+        },
+        "timeLastUsed": {
+          "type": "number",
+          "optional": true,
+          "description": "See Login type for description."
+        },
+        "timePasswordChanged": {
+          "type": "number",
+          "optional": true,
+          "description": "See Login type for description."
+        },
+        "timesUsed": {
+          "type": "number",
+          "optional": true,
+          "description": "See Login type for description."
+        },
+        "timesUsedIncrement": {
+          "type": "number",
+          "optional": true,
+          "description": "Convenience property to allow the timesUsed value to be incremented without getting the Login first."
+        },
+        "username": {
+          "type": "string",
+          "optional": true,
+          "description": "See Login type for description."
+        },
+        "usernameField": {
+          "type": "string",
+          "optional": true,
+          "description": "See Login type for description."
+        }
+      }
+    }],
+    "events": [
+      {
+        "name": "onCreated",
+        "type": "function",
+        "description": "Fired when a Login is created. Event includes the newly-created Login.",
+        "parameters": [
+          {
+            "type": "object",
+            "name": "changeInfo",
+            "properties": {
+              "login": {
+                "$ref": "Login"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "onUpdated",
+        "type": "function",
+        "description": "Fired when an existing Login is updated. Event includes the updated Login.",
+        "parameters": [
+          {
+            "type": "object",
+            "name": "changeInfo",
+            "properties": {
+              "login": {
+                "$ref": "Login"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "onRemoved",
+        "type": "function",
+        "description": "Fired when a Login is deleted. Event includes the deleted Login.",
+        "parameters": [
+          {
+            "type": "object",
+            "name": "changeInfo",
+            "properties": {
+              "login": {
+                "$ref": "Login"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "onAllRemoved",
+        "type": "function",
+        "description": "Fired when all Logins are removed."
+      }
+    ],
+    "functions": [
+      {
+        "name": "getAll",
+        "type": "function",
+        "description": "Gets an array of all Logins. Returns a Promise for the (possibly empty) list of all Logins.",
+        "async": true,
+        "parameters": []
+      },
+      {
+        "name": "get",
+        "type": "function",
+        "description": "Gets a Login, given a Mozilla-GUID. Returns a Promise that resolves to the Login, if the Mozilla-GUID was found, or null, if it was not found.",
+        "async": true,
+        "parameters": [{
+          "name": "id",
+          "$ref": "Mozilla-GUID",
+          "description": "The Mozilla-GUID of the Login to retrieve."
+        }]
+      },
+      {
+        "name": "add",
+        "type": "function",
+        "description": "Creates a new Login. Returns a Promise that resolves to the newly-created Login, if successful. Rejects the returned Promise if the Mozilla-GUID already exists, or if required fields are missing or malformed.",
+        "async": true,
+        "parameters": [{
+          "name": "loginInfo",
+          "description": "Object containing required fields for a new Login.",
+          "$ref": "Login"
+        }]
+      },
+      {
+        "name": "update",
+        "type": "function",
+        "description": "Updates an existing Login (either nsILoginInfo or nsILoginMetaData fields). Requires passing the Mozilla-GUID and any fields to be updated. Note: use 'timesUsedIncrement' to increment 'timesUsed', rather than getting and checking the existing value first. Returns a Promise that resolves to the updated Login, if successful. Rejects the returned Promise if the Mozilla-GUID was not found, or if any fields were malformed.",
+        "async": true,
+        "parameters": [{
+          "name": "loginInfo",
+          "$ref": "LoginUpdate",
+          "description": "Object containing Mozilla-GUID and any fields to be updated."
+        }]
+      },
+      {
+        "name": "remove",
+        "type": "function",
+        "description": "Removes the Login identified by the Mozilla-GUID. Returns a Promise that resolves if the Login is successfully removed. Rejects the returned Promise if the Login was not found.",
+        "async": true,
+        "parameters": [{
+          "name": "id",
+          "$ref": "Mozilla-GUID",
+          "description": "The Mozilla-GUID of the Login to be removed."
+        }]
+      }
+    ]
+  }
+]

--- a/src/manifest.json.tpl
+++ b/src/manifest.json.tpl
@@ -38,6 +38,17 @@
     }
   },
 
+  "experiment_apis": {
+    "logins": {
+      "schema": "experiments/logins/schema.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "script": "experiments/logins/api.js",
+        "paths": [["experiments", "logins"]]
+      }
+    }
+  },
+
   "permissions": [
     "tabs",
     "clipboardRead",

--- a/test/integration/driver.js
+++ b/test/integration/driver.js
@@ -16,6 +16,7 @@ const DEFAULT_PREFS = {
   "xpinstall.signatures.required": false,
   "devtools.chrome.enabled": true,
   "devtools.debugger.remote-enabled": true,
+  "extensions.legacy.enabled": true,
 };
 
 // Lockbox specific environment variables ...

--- a/test/integration/functional-test.js
+++ b/test/integration/functional-test.js
@@ -38,7 +38,7 @@ describe("Lockbox functional testing", () => {
     expect(doorhanger).to.not.be.null;
   });
 
-  after(() => {
-    webext.stop();
+  after(async () => {
+    await webext.stop();
   });
 });

--- a/test/integration/logins-api-test.js
+++ b/test/integration/logins-api-test.js
@@ -7,7 +7,6 @@
 import getWebExtension from "./driver";
 import chai, { expect } from "chai";
 import chaiAsPromised from "chai-as-promised";
-import createHelper from "./helper";
 
 chai.use(chaiAsPromised);
 
@@ -23,7 +22,7 @@ const mockLogin = {
   usernameField: "username",
   passwordField: "password",
   username: "creativeusername",
-  password: "p455w0rd"
+  password: "p455w0rd",
 };
 
 describe("logins API", () => {
@@ -49,7 +48,7 @@ describe("logins API", () => {
         usernameField: "username",
         passwordField: "password",
         username: "creativeusername",
-        password: "p455w0rd"
+        password: "p455w0rd",
       };
       const login = LoginHelper.vanillaObjectToLogin(mockLogin);
       Services.logins.addLogin(login);
@@ -66,7 +65,7 @@ describe("logins API", () => {
 
   const loadTestPage = async () => {
     await webext.inContent();
-    await driver.get(webext.url('/test/integration/test-pages/logins-api.html'));
+    await driver.get(webext.url("/test/integration/test-pages/logins-api.html"));
   };
 
   const clickButton = async (id) => {
@@ -107,7 +106,7 @@ describe("logins API", () => {
   it("browser.experiments.logins.add should add a new login", async () => {
     await webext.inChrome();
     const initialLogins = await getLogins();
-    expect(initialLogins).to.be.an('array').that.is.empty;
+    expect(initialLogins).to.be.an("array").that.is.empty;
 
     await loadTestPage();
     await clickButton("add");
@@ -125,7 +124,7 @@ describe("logins API", () => {
 
     await webext.inChrome();
     const results = await getLogins();
-    expect(results).to.be.an('array').that.is.empty;
+    expect(results).to.be.an("array").that.is.empty;
   });
 
   it("browser.experiments.logins.get should return the login", async () => {
@@ -137,7 +136,7 @@ describe("logins API", () => {
     const results = await driver.wait(until.elementLocated(
       By.id("get-results")
     ), 1000);
-    await driver.wait(until.elementTextContains(results, 'guid'), 5000);
+    await driver.wait(until.elementTextContains(results, "guid"), 5000);
     const output = await results.getText();
     expect(JSON.parse(output)).to.deep.equal(mockLogin);
   });
@@ -151,7 +150,7 @@ describe("logins API", () => {
     const results = await driver.wait(until.elementLocated(
       By.id("get-all-results")
     ), 1000);
-    await driver.wait(until.elementTextContains(results, 'guid'), 5000);
+    await driver.wait(until.elementTextContains(results, "guid"), 5000);
     const output = await results.getText();
     expect(JSON.parse(output)).to.deep.equal([mockLogin]);
   });

--- a/test/integration/logins-api-test.js
+++ b/test/integration/logins-api-test.js
@@ -1,0 +1,97 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import getWebExtension from "./driver";
+import chai, { expect } from "chai";
+import chaiAsPromised from "chai-as-promised";
+import createHelper from "./helper";
+
+chai.use(chaiAsPromised);
+
+const mockLogin = {
+  guid: "{33535344-9cdb-8c4a-ae10-5849d0a2f04a}",
+  timeCreated: 1546291981955,
+  timeLastUsed: 1546291981955,
+  timePasswordChanged: 1546291981955,
+  timesUsed: 1,
+  hostname: "https://example.com",
+  formSubmitURL: "https://example.com",
+  usernameField: "username",
+  passwordField: "password",
+  username: "creativeusername",
+  password: "p455w0rd"
+};
+
+describe("logins API", () => {
+  let webext;
+  let driver;
+
+
+  before(async () => {
+    webext = await getWebExtension();
+    await webext.start();
+    driver = await webext.driver;
+    await webext.inChrome();
+    await driver.executeScript(`
+      ChromeUtils.defineModuleGetter(this, "LoginHelper",
+                                     "resource://gre/modules/LoginHelper.jsm");
+      ChromeUtils.defineModuleGetter(this, "Services",
+                                     "resource://gre/modules/Services.jsm");
+    `);
+  });
+
+  beforeEach(async () => {
+    await webext.inChrome();
+    await driver.executeScript(`
+      Services.logins.removeAllLogins();
+    `);
+  });
+
+  afterEach(async () => {
+  });
+
+  after(async () => {
+    await driver.quit();
+  });
+
+  it("browser.experiments.logins.add should add a new login", async () => {
+    const { webdriver } = webext;
+    const { By, until } = webdriver;
+
+    // 1. verify no logins.
+    await webext.inChrome();
+    const initialLogins = await driver.executeScript(`
+      return Services.logins.getAllLogins().map(LoginHelper.loginToVanillaObject);
+    `);
+    expect(initialLogins).to.be.an('array').that.is.empty;
+
+    // 2. open test page & add login via API.
+    await webext.inContent();
+    await driver.get(webext.url('/test/integration/test-pages/logins-api.html'));
+    const btn = await driver.wait(until.elementLocated(
+      By.id("add")
+    ), 1000);
+    await btn.click();
+    // verify there's something in the output
+    const results = await driver.wait(until.elementLocated(
+      By.id("add-results")
+    ), 1000);
+    // temporarily insert a super long wait, so we can examine the running test
+    // TODO: why is browser.experiments.logins undefined when the test loads the URL,
+    // but available when I load the page from browser.tabs.create() in the about:debugger debugger?
+    await driver.wait(until.elementTextContains(results, 'guid'),30000);
+    const output = results.getText();
+    expect(output).to.equal('foo');
+
+    // 3. verify login.
+    await webext.inChrome();
+    const finalLogin = await driver.executeScript(`
+      const login = Services.logins.getAllLogins()[0];
+      return LoginHelper.loginToVanillaObject(login);
+    `);
+    expect(finalLogin).to.deep.equal(mockLogin);
+  });
+});

--- a/test/integration/logins-api-test.js
+++ b/test/integration/logins-api-test.js
@@ -100,7 +100,7 @@ describe("logins API", () => {
   });
 
   after(async () => {
-    await driver.quit();
+    await webext.stop();
   });
 
   it("browser.experiments.logins.add should add a new login", async () => {

--- a/test/integration/logins-api-test.js
+++ b/test/integration/logins-api-test.js
@@ -161,8 +161,9 @@ describe("logins API", () => {
     await loadTestPage();
     await clickButton("update");
 
+    await getLogins();
     const logins = await getLogins();
-    expect(logins[0].username).to.equal(mockLogin.username);
+    expect(logins[0].username).to.equal("updated");
   });
 
   it("browser.experiments.logins.touch should update the timesUsed and lastTimeUsed values", async () => {

--- a/test/integration/logins-api-test.js
+++ b/test/integration/logins-api-test.js
@@ -18,6 +18,7 @@ const mockLogin = {
   timePasswordChanged: 1546291981955,
   timesUsed: 1,
   hostname: "https://example.com",
+  httpRealm: null,
   formSubmitURL: "https://example.com",
   usernameField: "username",
   passwordField: "password",
@@ -28,12 +29,61 @@ const mockLogin = {
 describe("logins API", () => {
   let webext;
   let driver;
+  let webdriver;
+  let By;
+  let until;
 
+  const addLogin = async () => {
+    await webext.inChrome();
+    await driver.executeScript(`
+      // XXX For some reason, template substitution doesn't work with selenium
+      const mockLogin = {
+        guid: "{33535344-9cdb-8c4a-ae10-5849d0a2f04a}",
+        timeCreated: 1546291981955,
+        timeLastUsed: 1546291981955,
+        timePasswordChanged: 1546291981955,
+        timesUsed: 1,
+        hostname: "https://example.com",
+        httpRealm: null,
+        formSubmitURL: "https://example.com",
+        usernameField: "username",
+        passwordField: "password",
+        username: "creativeusername",
+        password: "p455w0rd"
+      };
+      const login = LoginHelper.vanillaObjectToLogin(mockLogin);
+      Services.logins.addLogin(login);
+    `);
+  };
+
+  const getLogins = async () => {
+    await webext.inChrome();
+    const logins = await driver.executeScript(`
+      return Services.logins.getAllLogins().map(LoginHelper.loginToVanillaObject);
+    `);
+    return logins;
+  };
+
+  const loadTestPage = async () => {
+    await webext.inContent();
+    await driver.get(webext.url('/test/integration/test-pages/logins-api.html'));
+  };
+
+  const clickButton = async (id) => {
+    await webext.inContent();
+    const btn = await driver.wait(until.elementLocated(
+      By.id(id)
+    ), 1000);
+    await btn.click();
+  };
 
   before(async () => {
     webext = await getWebExtension();
     await webext.start();
     driver = await webext.driver;
+    webdriver = webext.webdriver;
+    By = webdriver.By;
+    until = webdriver.until;
     await webext.inChrome();
     await driver.executeScript(`
       ChromeUtils.defineModuleGetter(this, "LoginHelper",
@@ -50,48 +100,79 @@ describe("logins API", () => {
     `);
   });
 
-  afterEach(async () => {
-  });
-
   after(async () => {
     await driver.quit();
   });
 
   it("browser.experiments.logins.add should add a new login", async () => {
-    const { webdriver } = webext;
-    const { By, until } = webdriver;
-
-    // 1. verify no logins.
     await webext.inChrome();
-    const initialLogins = await driver.executeScript(`
-      return Services.logins.getAllLogins().map(LoginHelper.loginToVanillaObject);
-    `);
+    const initialLogins = await getLogins();
     expect(initialLogins).to.be.an('array').that.is.empty;
 
-    // 2. open test page & add login via API.
-    await webext.inContent();
-    await driver.get(webext.url('/test/integration/test-pages/logins-api.html'));
-    const btn = await driver.wait(until.elementLocated(
-      By.id("add")
-    ), 1000);
-    await btn.click();
-    // verify there's something in the output
-    const results = await driver.wait(until.elementLocated(
-      By.id("add-results")
-    ), 1000);
-    // temporarily insert a super long wait, so we can examine the running test
-    // TODO: why is browser.experiments.logins undefined when the test loads the URL,
-    // but available when I load the page from browser.tabs.create() in the about:debugger debugger?
-    await driver.wait(until.elementTextContains(results, 'guid'),30000);
-    const output = results.getText();
-    expect(output).to.equal('foo');
+    await loadTestPage();
+    await clickButton("add");
 
-    // 3. verify login.
     await webext.inChrome();
-    const finalLogin = await driver.executeScript(`
-      const login = Services.logins.getAllLogins()[0];
-      return LoginHelper.loginToVanillaObject(login);
-    `);
-    expect(finalLogin).to.deep.equal(mockLogin);
+    const finalLogins = await getLogins();
+    expect(finalLogins[0]).to.deep.equal(mockLogin);
+  });
+
+  it("browser.experiments.logins.remove should remove the login", async () => {
+    await addLogin();
+
+    await loadTestPage();
+    await clickButton("remove");
+
+    await webext.inChrome();
+    const results = await getLogins();
+    expect(results).to.be.an('array').that.is.empty;
+  });
+
+  it("browser.experiments.logins.get should return the login", async () => {
+    await addLogin();
+
+    await loadTestPage();
+    await clickButton("get");
+
+    const results = await driver.wait(until.elementLocated(
+      By.id("get-results")
+    ), 1000);
+    await driver.wait(until.elementTextContains(results, 'guid'), 5000);
+    const output = await results.getText();
+    expect(JSON.parse(output)).to.deep.equal(mockLogin);
+  });
+
+  it("browser.experiments.logins.getAll should return the login in an array", async () => {
+    await addLogin();
+
+    await loadTestPage();
+    await clickButton("get-all");
+
+    const results = await driver.wait(until.elementLocated(
+      By.id("get-all-results")
+    ), 1000);
+    await driver.wait(until.elementTextContains(results, 'guid'), 5000);
+    const output = await results.getText();
+    expect(JSON.parse(output)).to.deep.equal([mockLogin]);
+  });
+
+  it("browser.experiments.logins.update should update the username", async () => {
+    await addLogin();
+
+    await loadTestPage();
+    await clickButton("update");
+
+    const logins = await getLogins();
+    expect(logins[0].username).to.equal(mockLogin.username);
+  });
+
+  it("browser.experiments.logins.touch should update the timesUsed and lastTimeUsed values", async () => {
+    await addLogin();
+
+    await loadTestPage();
+    await clickButton("touch");
+
+    const logins = await getLogins();
+    expect(logins[0].timesUsed).to.equal(2);
   });
 });

--- a/test/integration/test-pages/logins-api.html
+++ b/test/integration/test-pages/logins-api.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<meta charset="utf-8">
+<h1>Logins API Test File</h1>
+<p>This file allows the browser.experiments.logins.* API methods to be
+   called by programmatically clicking buttons. The results of the
+   API invocation can then be verified in the parent process, by calling
+   LoginManager methods. The return values can be checked by looking at
+   the results logged in the named &lt;pre&gt; fields.
+
+<p>Click the Add button to add the test login.
+  <button id="add">Add</button>
+  <pre id="add-results"></pre>
+
+<p>Click the Get button to get the login with the test ID.
+  <button id="get">Get</button>
+  <pre id="get-results"></pre>
+
+<p>Click the Get All button to get all logins.
+  <button id="get-all">Get All</button>
+  <pre id="get-all-results"></pre>
+
+<p>Click the Remove button to remove the test login.
+  <button id="remove">Remove</button>
+  <pre id="remove-results"></pre>
+
+<p>Click the Update button to modify the test login, setting the username to 'updated'.
+  <button id="update">Update</button>
+  <pre id="update-results"></pre>
+
+<p>Click the Touch button to modify the test login, updating its timeLastUsed and
+   incrementing its timesUsed counter.
+  <button id="touch">Touch</button>
+  <pre id="touch-results"></pre>
+
+<script src="logins-api.js"></script>

--- a/test/integration/test-pages/logins-api.js
+++ b/test/integration/test-pages/logins-api.js
@@ -1,0 +1,57 @@
+const mockLogin = {
+  guid: "{33535344-9cdb-8c4a-ae10-5849d0a2f04a}",
+  timeCreated: 1546291981955,
+  timeLastUsed: 1546291981955,
+  timePasswordChanged: 1546291981955,
+  timesUsed: 1,
+  hostname: "https://example.com",
+  httpRealm: null,
+  formSubmitURL: "https://example.com",
+  usernameField: "username",
+  passwordField: "password",
+  username: "creativeusername",
+  password: "p455w0rd"
+};
+
+// Returns a function that logs to a DOM element.
+const getLogger = (id) => {
+  return (result) => {
+    let target = document.querySelector(`#${id}-results`);
+    target.textContent = result instanceof Error ? result.toString() : JSON.stringify(result);
+  };
+};
+
+document.querySelector("#get").addEventListener("click", () => {
+  const log = getLogger("get");
+  browser.experiments.logins.get(mockLogin.guid).
+    then(log, log);
+});
+document.querySelector("#get-all").addEventListener("click", () => {
+  const log = getLogger("get-all");
+  browser.experiments.logins.getAll().
+    then(log, log);
+});
+document.querySelector("#add").addEventListener("click", () => {
+  const log = getLogger("add");
+  browser.experiments.logins.add(mockLogin).
+    then(log, log);
+});
+document.querySelector("#remove").addEventListener("click", () => {
+  const log = getLogger("remove");
+  browser.experiments.logins.remove(mockLogin.guid).
+    then(log, log);
+});
+document.querySelector("#update").addEventListener("click", () => {
+  const log = getLogger("update");
+  const loginUpdates = {
+    guid: mockLogin.guid,
+    username: "updated",
+  };
+  browser.experiments.logins.update(loginUpdates).
+    then(log, log);
+});
+document.querySelector("#touch").addEventListener("click", () => {
+  const log = getLogger("touch");
+  browser.experiments.logins.touch(mockLogin.guid).
+    then(log, log);
+});

--- a/test/integration/test-pages/logins-api.js
+++ b/test/integration/test-pages/logins-api.js
@@ -10,7 +10,7 @@ const mockLogin = {
   usernameField: "username",
   passwordField: "password",
   username: "creativeusername",
-  password: "p455w0rd"
+  password: "p455w0rd",
 };
 
 // Returns a function that logs to a DOM element.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -159,6 +159,6 @@ if (NODE_ENV === "test") {
         from: "../test/integration/test-pages/**/*",
         to: "test/",
       },
-    ], {debug: 'debug'}),
+    ]),
   );
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -150,3 +150,15 @@ module.exports = {
     },
   },
 };
+
+if (NODE_ENV === "test") {
+  // Include the test file for exercising the API in test mode
+  module.exports.plugins.push(
+    new CopyWebpackPlugin([
+      {
+        from: "../test/integration/test-pages/**/*",
+        to: "test/",
+      },
+    ], {debug: 'debug'}),
+  );
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -109,6 +109,7 @@ module.exports = {
       { from: "icons/", to: "icons/" },
       { from: "images/", to: "images/" },
       { from: "locales/", to: "locales/", transform: transformLocalesJSON },
+      { from: "experiments/", to: "experiments/" },
     ], {
       ignore: ["README*"],
     }),


### PR DESCRIPTION
Fixes #4.

## Testing and Review Notes

This is just the logins API as an embedded API experiment--it doesn't yet connect to the rest of the addon code, and it's marked WIP because I haven't finished the tests yet.

Most of the documentation of the Login type in the schema comes straight from the nsILoginInfo and nsILoginMetaInfo interface definitions. Because LoginManager.update() allows any of the properties to be updated, I opted to add a second LoginUpdate type with all of the properties marked optional (and adding the convenient `timesUsedIncrement` shortcut). The webextension API schemas don't currently specify return types, so the return info is in the description.

I've opted to structure parts of the code in keeping with in-tree API conventions, though they seem kinda odd to me; I'll call those spots out inline.

-----

How to play around with the API:

1. Fire up nightly via `npm run run -- -f nightly`
2. Open up `about:debugging`
3. Click the 'Debug' button to open a debugger
4. In the debugger console, set up your listeners and a dummy Login by pasting in this code:

```js
login =  {
  guid: "{33535344-9cdb-8c4a-ae10-5849d0a2f04a}",
  timeCreated: 1546291981955,
  timeLastUsed: 1546291981955,
  timePasswordChanged: 1546291981955,
  timesUsed: 1,
  hostname: "https://example.com",
  httpRealm: null,
  formSubmitURL: "https://example.com",
  usernameField: "username",
  passwordField: "password",
  username: "creativeusername",
  password: "p455w0rd"
};
browser.experiments.logins.onAdded.addListener(login => console.log("onAdded fired: ", login))
browser.experiments.logins.onUpdated.addListener(login => console.log("onUpdated fired: ", login))
browser.experiments.logins.onRemoved.addListener(login => console.log("onRemoved fired: ", login))
```

5. Now you can play around with creating, updating, and removing logins:

```js
await browser.experiments.logins.getAll();
await browser.experiments.logins.add(login);
await browser.experiments.logins.get(login.guid);
await browser.experiments.logins.getAll();
login.username = "originalusername";
await browser.experiments.logins.update(login);
await browser.experiments.logins.touch(login.guid); // note: fires onUpdated
await browser.experiments.logins.remove(login.guid);
```

You can try to trigger errors by adding the login twice in a row, or removing it twice in a row, or setting incorrect field types when adding or updating, etc. You can also open up the login manager (`about:preferences#privacy`) and make changes there, then verify that the corresponding events fire in the debugger.

*Edited to change onCreated to onAdded in debugger setup script, and add touch() reference*