### PR TITLE
Specify node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "version": "2.0.0-alpha",
   "description": "Take your passwords everywhere.",
   "engines": {
-    "firefox": ">= 63"
+    "firefox": ">= 63",
+    "node" : ">=10.15.0"
   },
   "scripts": {
     "autolint": "npm run :autolint:js && npm run :autolint:css",


### PR DESCRIPTION
- refs #49 

I was on an old node version that didn't support `fs.promises` which was making the build fail for me, adding this for other clumsy devs like myself.