### PR TITLE
Initial minimal logins API connection to datastore

### DIFF
--- a/src/background/datastore.js
+++ b/src/background/datastore.js
@@ -144,7 +144,6 @@ class DataStore {
       timePasswordChanged: Date.now(),
     };
     await browser.experiments.logins.add(added);
-    this._all[added.guid] = added;
 
     added = convertInfo2Item(added);
     recordMetric("added", added.id);
@@ -168,7 +167,6 @@ class DataStore {
       timePasswordChanged: Date.now(),
     };
     await browser.experiments.logins.update(updated);
-    this._all[updated.guid] = updated;
 
     updated = convertInfo2Item(updated);
     recordMetric("updated", item.id);
@@ -179,8 +177,6 @@ class DataStore {
     const item = await this.get(id);
     if (item) {
       await browser.experiments.logins.remove(item.id);
-      delete this._all[item.id];
-
       recordMetric("deleted", item.id);
     }
     return item || null;
@@ -208,9 +204,9 @@ class DataStore {
     broadcast({ type: "updated_item", item });
   }
 
-  removeInfo(info) {
-    delete this._all[info.guid];
-    broadcast({ type: "removed_item", id: info.guid });
+  removeInfo({ guid }) {
+    delete this._all[guid];
+    broadcast({ type: "removed_item", id: guid });
   }
 }
 

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -7,9 +7,11 @@
 import updateBrowserAction from "./browser-action";
 import initializeMessagePorts from "./message-ports";
 import { initializeTelemetry } from "./telemetry";
+import { initializeDataStore } from "./datastore";
 
 Promise.resolve().then(async () => {
   initializeTelemetry();
   initializeMessagePorts();
+  await initializeDataStore();
   await updateBrowserAction();
 });

--- a/src/background/message-ports.js
+++ b/src/background/message-ports.js
@@ -10,7 +10,7 @@ import clipboard from "./clipboard";
 
 const ports = new Set();
 
-function broadcast(message, excludedSender) {
+export function broadcast(message, excludedSender) {
   for (let p of ports) {
     if (!excludedSender || p.sender.contextId !== excludedSender.contextId) {
       p.postMessage(message);

--- a/src/background/message-ports.js
+++ b/src/background/message-ports.js
@@ -44,19 +44,16 @@ export default function initializeMessagePorts() {
     case "add_item":
       return openDataStore().then(async (ds) => {
         const item = await ds.add(message.item);
-        broadcast({type: "added_item", item}, sender);
         return {item};
       });
     case "update_item":
       return openDataStore().then(async (ds) => {
         const item = await ds.update(message.item);
-        broadcast({ type: "updated_item", item }, sender);
         return { item };
       });
     case "remove_item":
       return openDataStore().then(async (ds) => {
         await ds.remove(message.id);
-        broadcast({type: "removed_item", id: message.id}, sender);
         return {};
       });
 

--- a/src/list/reducers.js
+++ b/src/list/reducers.js
@@ -37,7 +37,13 @@ export function cacheReducer(state = {items: [], currentItem: null}, action) {
   case actions.ADD_ITEM_COMPLETED:
     return {
       ...state,
-      items: [...state.items, makeItemSummary(action.item)],
+      items: [
+        // HACK: add dispatched via Logins API events may be a duplicate
+        // of an add we just completed in this UI - this filter makes it
+        // idempotent
+        ...state.items.filter(x => x.id != action.item.id),
+        makeItemSummary(action.item),
+      ],
       ...maybeAddCurrentItem(state, action),
     };
   case actions.UPDATE_ITEM_COMPLETED:

--- a/test/unit/background/datastore-test.js
+++ b/test/unit/background/datastore-test.js
@@ -1,0 +1,266 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { expect } from "chai";
+import sinon from "sinon";
+
+import "test/unit/mocks/browser";
+
+import {
+  initializeDataStore,
+  openDataStore,
+  closeDataStore,
+  convertInfo2Item,
+  convertItem2Info,
+} from "src/background/datastore";
+
+const LOGINS_METHODS = ["getAll", "add", "update", "remove"];
+const LOGINS_EVENTS = ["Added", "Updated", "Removed"].map(name => `on${name}`);
+
+describe("background > datastore", () => {
+  let store;
+
+  beforeEach(async () => {
+    for (let name of LOGINS_METHODS) {
+      sinon.stub(browser.experiments.logins, name);
+    }
+    const infos = Object.values(SAMPLE_INFOS);
+    browser.experiments.logins.getAll.resolves(infos);
+    await initializeDataStore();
+    store = await openDataStore();
+  });
+
+  afterEach(async () => {
+    for (let name of LOGINS_METHODS) {
+      browser.experiments.logins[name].restore();
+    }
+    for (let name of LOGINS_EVENTS) {
+      browser.experiments.logins[name].mockClearListener();
+    }
+    await closeDataStore();
+  });
+
+  it("sets up Logins API event listeners in initializeDataStore()", async () => {
+    for (let name of LOGINS_EVENTS) {
+      const ev = browser.experiments.logins[name];
+      expect(ev.getListener()).to.be.a("function");
+    }
+  });
+
+  it("yields a datastore instance from openDataStore()", async () => {
+    const store = await openDataStore();
+    expect(store).to.not.be.undefined;
+    const expectedLength = Object.values(SAMPLE_INFOS).length;
+    expect(await store.list()).to.have.length(expectedLength);
+  });
+
+  it("fetches initial items from Logins API", async () => {
+    expect(browser.experiments.logins.getAll.callCount).to.equal(1);
+
+    // TODO: Issue #21 should do away with item/info conversion
+    const expectedItems = Object.values(SAMPLE_INFOS)
+      .map(convertInfo2Item)
+      .sort(cmpAlphaBy("id"));
+    const resultItems = (await store.list()).sort(cmpAlphaBy("id"));
+
+    expect(resultItems).to.deep.equal(expectedItems);
+  });
+
+  it("handles onAdded event from Logins API", async () => {
+    const beforeItem = await store.get("XYZZY");
+    expect(beforeItem).to.equal(null);
+
+    const info = {
+      guid: "XYZZY",
+      title: "XYZZY title",
+      hostname: "http://XYZZY.example.com",
+      httpRealm: null,
+      username: "XYZZYuser",
+      password: "XYZZYpass",
+      usernameField: "username",
+      passwordField: "password",
+    };
+
+    const addedListener = browser.experiments.logins.onAdded.getListener();
+    addedListener({ login: info });
+
+    // TODO: Issue #21 should do away with item/info conversion
+    const expectedItem = convertInfo2Item(info);
+    const afterItem = await store.get("XYZZY");
+    expect(afterItem).to.deep.equal(expectedItem);
+  });
+
+  it("handles onUpdated event from Logins API", async () => {
+    const info = {
+      ...SAMPLE_INFOS.FOO,
+      password: "updated FOO password",
+    };
+
+    const updatedListener = browser.experiments.logins.onUpdated.getListener();
+    updatedListener({ login: info });
+
+    // TODO: Issue #21 should do away with item/info conversion
+    const expectedItem = convertInfo2Item(info);
+    const resultItem = await store.get("FOO");
+    expect(resultItem).to.deep.equal(expectedItem);
+  });
+
+  it("handles onRemoved event from Logins API", async () => {
+    const info = {
+      ...SAMPLE_INFOS.BAR,
+      password: "updated BAR password",
+    };
+
+    const removedListener = browser.experiments.logins.onRemoved.getListener();
+    removedListener({ login: info });
+
+    const resultItem = await store.get("BAR");
+    expect(resultItem).to.equal(null);
+  });
+
+  it("allows an item to be fetched", async () => {
+    // TODO: Issue #21 should do away with item/info conversion
+    const expectedItem = convertInfo2Item(SAMPLE_INFOS.FOO);
+    const resultItem = await store.get("FOO");
+    expect(resultItem).to.deep.equal(expectedItem);
+  });
+
+  it("allows an item to be added", async () => {
+    const info = {
+      title: "QUUX title",
+      hostname: "http://quux.example.com",
+      formSubmitURL: "http://quux.example.com",
+      httpRealm: null,
+      username: "QUUXuser",
+      password: "QUUXpass",
+      usernameField: "username",
+      passwordField: "password",
+    };
+    const item = convertInfo2Item(info);
+
+    // TODO: Issue #21 should do away with item/info conversion
+    const addedItem = await store.add(item);
+    const expectedItem = {
+      ...item,
+      id: addedItem.id,
+    };
+    expect(addedItem).to.deep.equal(expectedItem);
+
+    const resultItem = await store.get(addedItem.id);
+    expect(resultItem).to.deep.equal(addedItem);
+
+    const apiAdd = browser.experiments.logins.add;
+    expect(apiAdd.callCount).to.equal(1);
+
+    const expectedApiInfo = {
+      // TODO: Issue #21 should do away with item/info conversion
+      // A double conversion - semi-reflects what happens.
+      ...convertItem2Info(item),
+      guid: addedItem.id,
+    };
+
+    const {
+      timesUsed,
+      timeLastUsed,
+      timeCreated,
+      timePasswordChanged,
+      ...resultApiInfo
+    } = apiAdd.lastCall.lastArg;
+
+    expect(timesUsed).to.equal(0);
+    expect(timeLastUsed).to.not.be.undefined;
+    expect(timeCreated).to.not.be.undefined;
+    expect(timePasswordChanged).to.not.be.undefined;
+    expect(resultApiInfo).to.deep.equal(expectedApiInfo);
+  });
+
+  it("allows an item to be updated", async () => {
+    const id = "BAR";
+
+    const originalItem = await store.get(id);
+    const expectedItem = {
+      ...originalItem,
+      entry: {
+        ...originalItem.entry,
+        password: "updated password",
+      },
+    };
+
+    const updatedItem = await store.update(expectedItem);
+    expect(updatedItem).to.deep.equal(expectedItem);
+
+    const fetchedItem = await store.get(id);
+    expect(fetchedItem).to.deep.equal(expectedItem);
+
+    const apiUpdate = browser.experiments.logins.update;
+    expect(apiUpdate.callCount).to.equal(1);
+
+    const expectedApiInfo = {
+      // TODO: Issue #21 should do away with item/info conversion
+      // A double conversion - semi-reflects what happens.
+      ...convertItem2Info(expectedItem),
+      guid: expectedItem.id,
+    };
+
+    const {
+      timePasswordChanged,
+      ...resultApiInfo
+    } = apiUpdate.lastCall.lastArg;
+
+    expect(timePasswordChanged).to.not.be.undefined;
+    expect(resultApiInfo).to.deep.equal(expectedApiInfo);
+  });
+
+  it("allows an item to be removed", async () => {
+    const id = "BAZ";
+
+    const beforeItem = await store.get(id);
+    expect(beforeItem).to.not.equal(null);
+
+    const removedItem = await store.remove(id);
+    expect(removedItem).to.deep.equal(beforeItem);
+
+    const afterItem = await store.get(id);
+    expect(afterItem).to.equal(null);
+
+    const apiRemove = browser.experiments.logins.remove;
+    expect(apiRemove.callCount).to.equal(1);
+    expect(apiRemove.lastCall.lastArg).to.equal(id);
+  });
+});
+
+const cmpAlphaBy = name => (a, b) => a[name].localeCompare(b[name]);
+
+const SAMPLE_INFOS = {
+  FOO: {
+    guid: "FOO",
+    title: "FOO title",
+    hostname: "https://foo.example.com",
+    httpRealm: null,
+    username: "FOOuser",
+    password: "FOOpass",
+    usernameField: "username",
+    passwordField: "password",
+  },
+  BAR: {
+    guid: "BAR",
+    title: "BAR title",
+    hostname: "https://www.bar.example.com",
+    httpRealm: null,
+    username: "BARuser",
+    password: "BARpass",
+    usernameField: "username",
+    passwordField: "password",
+  },
+  BAZ: {
+    guid: "BAZ",
+    title: "BAZ title",
+    hostname: "http://baz.example.com",
+    httpRealm: null,
+    username: "BAZuser",
+    password: "BAZpass",
+    usernameField: "username",
+    passwordField: "password",
+  },
+};

--- a/test/unit/background/datastore-test.js
+++ b/test/unit/background/datastore-test.js
@@ -22,11 +22,25 @@ describe("background > datastore", () => {
   let store;
 
   beforeEach(async () => {
-    for (let name of LOGINS_METHODS) {
-      sinon.stub(browser.experiments.logins, name);
-    }
     const infos = Object.values(SAMPLE_INFOS);
-    browser.experiments.logins.getAll.resolves(infos);
+    sinon.stub(browser.experiments.logins, "getAll").resolves(infos);
+
+    sinon
+      .stub(browser.experiments.logins, "add")
+      .callsFake(login =>
+        browser.experiments.logins.onAdded.getListener()({ login }),
+      );
+    sinon
+      .stub(browser.experiments.logins, "update")
+      .callsFake(login =>
+        browser.experiments.logins.onUpdated.getListener()({ login }),
+      );
+    sinon
+      .stub(browser.experiments.logins, "remove")
+      .callsFake(guid =>
+        browser.experiments.logins.onRemoved.getListener()({ login: { guid } }),
+      );
+
     await initializeDataStore();
     store = await openDataStore();
   });
@@ -242,6 +256,10 @@ const SAMPLE_INFOS = {
     password: "FOOpass",
     usernameField: "username",
     passwordField: "password",
+    timesUsed: 1,
+    timeLastUsed: new Date("2019-01-03T12:00:00Z"),
+    timePasswordChanged: new Date("2019-01-02T12:00:00Z"),
+    timeCreated: new Date("2019-01-01T12:00:00Z"),
   },
   BAR: {
     guid: "BAR",
@@ -252,6 +270,10 @@ const SAMPLE_INFOS = {
     password: "BARpass",
     usernameField: "username",
     passwordField: "password",
+    timesUsed: 0,
+    timeLastUsed: new Date("2019-01-04T12:00:00Z"),
+    timePasswordChanged: new Date("2019-01-03T12:00:00Z"),
+    timeCreated: new Date("2019-01-02T12:00:00Z"),
   },
   BAZ: {
     guid: "BAZ",
@@ -262,5 +284,9 @@ const SAMPLE_INFOS = {
     password: "BAZpass",
     usernameField: "username",
     passwordField: "password",
+    timesUsed: 3,
+    timeLastUsed: new Date("2019-01-05T12:00:00Z"),
+    timePasswordChanged: new Date("2019-01-05T11:00:00Z"),
+    timeCreated: new Date("2019-01-05T10:00:00Z"),
   },
 };

--- a/test/unit/mocks/browser.js
+++ b/test/unit/mocks/browser.js
@@ -197,10 +197,16 @@ window.browser = {
 
   experiments: {
     logins: {
-      async getAll(item) { return []; },
-      async add(item) { },
-      async update(item) { },
-      async remove(id) { },
+      async getAll() { return []; },
+      async add(login) {
+        browser.experiments.logins.onAdded.getListener()({ login });
+      },
+      async update(login) {
+        browser.experiments.logins.onUpdated.getListener()({ login });
+      },
+      async remove(guid) {
+        browser.experiments.logins.onRemoved.getListener()({ login: { guid } });
+      },
       onAdded: new MockListener(),
       onUpdated: new MockListener(),
       onRemoved: new MockListener(),

--- a/test/unit/mocks/browser.js
+++ b/test/unit/mocks/browser.js
@@ -22,6 +22,10 @@ class MockListener {
     }
   }
 
+  getListener() {
+    return this._listener;
+  }
+
   mockClearListener() {
     this._listener = null;
   }
@@ -189,5 +193,17 @@ window.browser = {
 
     registerScalars(category, scalars) {},
     scalarSet(name, value) {},
+  },
+
+  experiments: {
+    logins: {
+      async getAll(item) { return []; },
+      async add(item) { },
+      async update(item) { },
+      async remove(id) { },
+      onAdded: new MockListener(),
+      onUpdated: new MockListener(),
+      onRemoved: new MockListener(),
+    },
   },
 };


### PR DESCRIPTION
Connected to #21

This doesn't actually fix #21, but it's kind of a start as it connects up the add-on to the real logins info data.

## Testing and Review Notes

* The add-on should now display real login entries
* Editing the login entries from the add-on should affect changes in the in-product login manager.
* Editing entries in the in-product login manager should affect changes in the add-on.