### PR TITLE
Implement Sync API (#23)

### DIFF
--- a/src/experiments/sync/api.js
+++ b/src/experiments/sync/api.js
@@ -1,0 +1,99 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/* globals ChromeUtils, ExtensionAPI, ExtensionCommon, ObjectUtils, Services,
+   UIState */
+
+"use strict";
+
+ChromeUtils.defineModuleGetter(this, "Services",
+                               "resource://gre/modules/Services.jsm");
+ChromeUtils.defineModuleGetter(this, "UIState",
+                               "resource://services-sync/UIState.jsm");
+ChromeUtils.defineModuleGetter(this, "ObjectUtils",
+                               "resource://gre/modules/ObjectUtils.jsm");
+
+const getProfileInfo = async () => {
+  const uiState = UIState.get();
+  // STATUS_LOGIN_FAILED means the password was changed on another device, and the
+  // user needs to log in again.
+  // STATUS_NOT_VERIFIED means the user has logged in with an unverified email.
+  // In both cases, the user needs to take action elsewhere in Firefox.
+  const errors = [UIState.STATUS_LOGIN_FAILED, UIState.STATUS_NOT_VERIFIED];
+
+  let profileInfo;
+
+  // STATUS_NOT_CONFIGURED means the user is not logged in.
+  if (uiState.status === UIState.STATUS_NOT_CONFIGURED) {
+    profileInfo = null;
+  } else { // UIState.STATUS_SIGNED_IN, the user is logged in and verified.
+    const fxa = await UIState._internal.fxAccounts.getSignedInUser();
+    const isErrorStatus = errors.includes(uiState.status);
+
+    profileInfo = {
+      id: fxa && fxa.uid,
+      email: uiState.email,
+      displayName: uiState.displayName || null,
+      avatar: uiState.avatarURL || null,
+      status: isErrorStatus ? "error" : "ok",
+    };
+  }
+
+  return profileInfo;
+};
+
+this.sync = class extends ExtensionAPI {
+  getAPI(context) {
+    const EventManager = ExtensionCommon.EventManager;
+    return {
+      experiments: {
+        sync: {
+          async getCurrentState(syncType) {
+            return Services.prefs.getBoolPref("services.sync.engine." + syncType, false);
+          },
+          async getUserProfileInfo() {
+            const profileInfo = await getProfileInfo();
+            return profileInfo;
+          },
+          onUserProfileChanged: new EventManager(context, "sync.onUserProfileChanged", async (fire) => {
+            let oldValue = await getProfileInfo();
+            const callback = (value) => {
+              fire.async(value);
+            };
+            const observer = {
+              observe: async (subject, topic, type) => {
+                const newProfileInfo = await getProfileInfo();
+                // Sync fires duplicate events. Filter out events where:
+                // - old and new UserProfileInfo are both null
+                // - old and new UserProfileInfo are objects with same values.
+                // Happily, ObjectUtils.deepEqual(null, null) is true.
+                if (ObjectUtils.deepEqual(oldValue, newProfileInfo)) {
+                  return;
+                }
+                // Sync also fires two events when a verified login occurs:
+                // one as soon as login succeeds, with status "ok" but null
+                // avatar and displayName, and a second after pinging the FxA
+                // profile server, with status 'ok' and non-null avatar and
+                // possibly non-null displayName. Suppress the first one.
+                if (newProfileInfo &&
+                    newProfileInfo.status === "ok" &&
+                    newProfileInfo.avatar === null) {
+                  return;
+                }
+                oldValue = newProfileInfo;
+                callback(newProfileInfo);
+              },
+            };
+            Services.obs.addObserver(observer, "sync-ui-state:update");
+            return () => {
+              Services.obs.removeObserver(observer, "sync-ui-state:update");
+            };
+          }).api(),
+        },
+      },
+    };
+  }
+};

--- a/src/experiments/sync/schema.json
+++ b/src/experiments/sync/schema.json
@@ -1,0 +1,94 @@
+[
+  {
+    "namespace": "experiments.sync",
+    "description": "Firefox Lockbox internal API for accessing Firefox Accounts/Sync state.",
+    "types": [
+      {
+        "id": "SyncType",
+        "type": "string",
+        "enum": ["addons", "addresses", "bookmarks", "creditcards", "history", "passwords", "prefs", "tabs"],
+        "description": "Represents different types of data that users can choose to sync across devices. Based on sync engine prefs in Firefox. Note that 'passwords' actually means logins."
+      },
+      {
+        "id": "SyncState",
+        "type": "boolean",
+        "description": "True if the user has enabled sync for the particular SyncType, false otherwise."
+      },
+      {
+        "id": "SyncStatus",
+        "type": "string",
+        "enum": ["error", "ok"],
+        "description": "Status of the user's login in Firefox. If the state is 'error', the user is logged in, but needs to take action to fix something, either a stale login or an unverified email. If the state is 'ok', the user is successfully logged in to Sync. Note: this is a string, not a boolean, in case we want to differentiate particular error states in the future."
+      },
+      {
+        "id": "UserProfileInfo",
+        "type": "object",
+        "description": "Firefox Accounts/Sync user profile info relevant to Lockbox.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "optional": false,
+            "description": "User's Firefox Account uid as a string."
+          },
+          "email": {
+            "type": "string",
+            "optional": false,
+            "description": "User's primary email as a string."
+          },
+          "displayName": {
+            "type": "any",
+            "optional": true,
+            "description": "User's display name as a string, or null if no display name has been set."
+          },
+          "avatar": {
+            "type": "any",
+            "optional": true,
+            "description": "URL of user's avatar as a string, or null if the login is in an error state. If the user hasn't added an avatar to their Firefox Account, the avatar will be the default URL, https://firefoxusercontent.com/00000000000000000000000000000000."
+          },
+          "status": {
+            "$ref": "SyncStatus",
+            "description": "Current Sync login status."
+          }
+        }
+      }
+    ],
+    "events": [
+      {
+        "name": "onUserProfileChanged",
+        "type": "function",
+        "description": "Event fired when the user profile changes due to a FxA/Sync status change. Event includes the updated UserProfileInfo object, or null if the user is logged out.",
+        "parameters": [
+          {
+            "type": "object",
+            "name": "changeInfo",
+            "properties": {
+              "login": {
+                "type": "any"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "functions": [
+      {
+        "name": "getCurrentState",
+        "type": "function",
+        "description": "Given a SyncType, returns a Promise that resolves to the SyncState for that type.",
+        "async": true,
+        "parameters": [{
+          "name": "type",
+          "$ref": "SyncType",
+          "description": "SyncType to check."
+        }]
+      },
+      {
+        "name": "getUserProfileInfo",
+        "type": "function",
+        "description": "Returns a Promise that resolves to the UserProfileInfo, if the user is logged in, or null otherwise.",
+        "async": true,
+        "parameters": []
+      }
+    ]
+  }
+]

--- a/src/manifest.json.tpl
+++ b/src/manifest.json.tpl
@@ -46,6 +46,14 @@
         "script": "experiments/logins/api.js",
         "paths": [["experiments", "logins"]]
       }
+    },
+    "sync": {
+      "schema": "experiments/sync/schema.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "script": "experiments/sync/api.js",
+        "paths": [["experiments", "sync"]]
+      }
     }
   },
 

--- a/test/integration/sync-api-test.js
+++ b/test/integration/sync-api-test.js
@@ -1,0 +1,310 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import getWebExtension from "./driver";
+import chai, { expect } from "chai";
+import chaiAsPromised from "chai-as-promised";
+
+chai.use(chaiAsPromised);
+
+describe("sync API", () => {
+  let webext, driver, webdriver, By, until;
+
+  const clickButton = async (id) => {
+    await webext.inContent();
+    const button = await driver.wait(until.elementLocated(By.id(id)), 5000);
+    await button.click();
+  };
+
+  const getResults = async (id) => {
+    await webext.inContent();
+    const results = await driver.wait(until.elementLocated(By.id(id)), 5000);
+    await driver.wait(until.elementTextMatches(results, /[a-z]/));
+    const output = results.getText();
+    return output;
+  };
+
+  const loadTestPage = async () => {
+    await webext.inContent();
+    await driver.get(webext.url("/test/integration/test-pages/sync-api.html"));
+  };
+
+
+  const getProfileInfo = async () => {
+    await clickButton("get-profile-info");
+    const profileInfo = await getResults("get-profile-info-results");
+    return profileInfo;
+  };
+
+  const registerOnUserProfileChangedListener = async () => {
+    await clickButton("register-listener");
+  };
+
+  const getUserProfileChangedEvents = async () => {
+    const results = await getResults("register-listener-results");
+    return results;
+  };
+
+  const getPasswordsPref = async () => {
+    await clickButton("check-passwords-pref");
+    const output = await getResults("check-passwords-pref-results");
+    return output;
+  };
+
+  // Force an update of the UIState. This method exists on the UIState API to
+  // aid with rapid state transitions during testing.
+  const refreshUIState = async () => {
+    await webext.inChrome();
+    await driver.executeAsyncScript(`(async () => {
+      ChromeUtils.defineModuleGetter(this, "UIState",
+                                     "resource://services-sync/UIState.jsm");
+      await UIState.refresh();
+    })().then(arguments[0]);
+    `);
+  };
+
+  // Fire the Firefox-internal event that causes the onUserProfileChanged API
+  // to fire (if the UIState has changed).
+  const triggerInternalSyncEvent = async () => {
+    await webext.inChrome();
+    await driver.executeScript(`
+      ChromeUtils.import("resource://gre/modules/Services.jsm");
+      Services.obs.notifyObservers(null, "sync-ui-state:update");
+    `);
+  };
+
+  /**
+   * The existing Firefox test code mocks out the UIState by setting the
+   * UIState._internal.fxAccounts values, then calling UIState.refresh()
+   * to trigger updates based on the mock data. The following helper methods
+   * are used to take the same approach in our tests.
+   *
+   * Reference: https://searchfox.org/mozilla-central/source/services/sync/tests/unit/test_uistate.js
+   */
+
+  // Mock out the logged in case, with default values.
+  const setLoggedIn = async () => {
+    await webext.inChrome();
+    await driver.executeAsyncScript(`(async () => {
+      const testTime = new Date("January 1, 2019");
+      ChromeUtils.import("resource://gre/modules/Services.jsm");
+      Services.prefs.setCharPref("services.sync.lastSync", testTime);
+      UIState._internal.syncing = false;
+
+      UIState._internal.fxAccounts = {
+        getSignedInUser: () => Promise.resolve({
+          uid: "0123456789abcdef0123456789abcdef",
+          verified: true,
+          email: "foo@example.com",
+        }),
+        // Use the defaults for displayName and avatarURL, to ensure we
+        // handle them correctly.
+        getSignedInUserProfile: () => Promise.resolve({
+          displayName: undefined,
+          uid: "0123456789abcdef0123456789abcdef",
+          avatar: "https://firefoxusercontent.com/00000000000000000000000000000000",
+        }),
+        hasLocalSession: () => Promise.resolve(true),
+      };
+
+      await UIState.refresh();
+    })().then(arguments[0]);
+    `);
+  };
+
+  // Mock out the state where the user is logged out or has never logged in.
+  const setNotConfigured = async () => {
+    await webext.inChrome();
+    await driver.executeAsyncScript(`(async () => {
+      const testTime = new Date("January 1, 2019");
+      ChromeUtils.import("resource://gre/modules/Services.jsm");
+      Services.prefs.setCharPref("services.sync.lastSync", testTime);
+      UIState._internal.syncing = false;
+
+      UIState._internal.fxAccounts = {
+        getSignedInUser: () => Promise.resolve(null),
+        getSignedInUserProfile: () => Promise.resolve(null),
+      };
+
+      await UIState.refresh();
+    })().then(arguments[0]);
+    `);
+  };
+
+  // Mock out the state where the user is logged in, but the password was
+  // changed on another device.
+  const setLoginFailed = async () => {
+    await webext.inChrome();
+    await driver.executeAsyncScript(`(async () => {
+      const testTime = new Date("January 1, 2019");
+      ChromeUtils.import("resource://gre/modules/Services.jsm");
+      Services.prefs.setCharPref("services.sync.lastSync", testTime);
+      UIState._internal.syncing = false;
+
+      Services.prefs.setStringPref("services.sync.username", "foo@example.com");
+      UIState._internal.fxAccounts = {
+        getSignedInUser: () => Promise.resolve({
+          email: "foo@example.com",
+          uid: "0123456789abcdef0123456789abcdef",
+          verified: true,
+        }),
+        getSignedInUserProfile: () => Promise.resolve(null),
+        hasLocalSession: () => Promise.resolve(),
+      };
+
+      await UIState.refresh();
+    })().then(arguments[0]);
+    `);
+  };
+
+  // Mock out the state where the user is logged in, but the email is
+  // unverified.
+  const setNotVerified = async () => {
+    await webext.inChrome();
+    await driver.executeAsyncScript(`(async () => {
+      const testTime = new Date("January 1, 2019");
+      ChromeUtils.import("resource://gre/modules/Services.jsm");
+      Services.prefs.setCharPref("services.sync.lastSync", testTime);
+      UIState._internal.syncing = false;
+
+      UIState._internal.fxAccounts = {
+        getSignedInUser: () => Promise.resolve({
+          verified: false,
+          uid: "0123456789abcdef0123456789abcdef",
+          email: "foo@example.com",
+        }),
+        getSignedInUserProfile: () => Promise.resolve(null),
+        hasLocalSession: () => Promise.resolve(true),
+      };
+
+      await UIState.refresh();
+    })().then(arguments[0]);
+    `);
+  };
+
+  const MockUserProfileInfo = {
+    loggedIn: {
+      status: "ok",
+      avatar: "https://firefoxusercontent.com/00000000000000000000000000000000",
+      email: "foo@example.com",
+      id: "0123456789abcdef0123456789abcdef",
+      displayName: null,
+    },
+    error: {
+      status: "error",
+      avatar: null,
+      email: "foo@example.com",
+      id: "0123456789abcdef0123456789abcdef",
+      displayName: null,
+    },
+  };
+
+  before(async () => {
+    webext = await getWebExtension();
+    await webext.start();
+    driver = await webext.driver;
+    webdriver = webext.webdriver;
+    By = webdriver.By;
+    until = webdriver.until;
+
+    await webext.inChrome();
+    await driver.executeScript(`
+      ChromeUtils.import("resource://gre/modules/Services.jsm");
+      ChromeUtils.import("resource://services-sync/UIState.jsm");
+    `);
+  });
+
+  after(async () => {
+    await webext.stop();
+  });
+
+  afterEach(async () => {
+    await webext.inChrome();
+    await driver.executeScript(`
+      ChromeUtils.import("resource://gre/modules/Services.jsm");
+      ChromeUtils.import("resource://services-sync/UIState.jsm");
+      Services.prefs.clearUserPref("services.sync.lastSync");
+      Services.prefs.clearUserPref("services.sync.username");
+      UIState._internal.fxAccounts = window.fxAccountsOrig;
+      UIState.reset();
+    `);
+  });
+
+  describe("browser.experiments.sync.getCurrentState", () => {
+    it("should correctly check the state of logins sync ", async () => {
+      await webext.inChrome();
+      driver.executeScript(`
+        ChromeUtils.import("resource://gre/modules/Services.jsm");
+        Services.prefs.setBoolPref("services.sync.engine.passwords", false);
+      `);
+      await refreshUIState();
+      await loadTestPage();
+      let result = await getPasswordsPref();
+      expect(JSON.parse(result)).to.be.false;
+
+      await webext.inChrome();
+      driver.executeScript(`
+        ChromeUtils.import("resource://gre/modules/Services.jsm");
+        Services.prefs.setBoolPref("services.sync.engine.passwords", true);
+      `);
+      await refreshUIState();
+      result = await getPasswordsPref();
+      expect(JSON.parse(result)).to.be.true;
+    });
+  });
+
+  describe("browser.experiments.sync.getUserProfileInfo", () => {
+    it("should return null if the user is not logged in", async () => {
+      await setNotConfigured();
+      await loadTestPage();
+      const profileInfo = await getProfileInfo();
+      expect(JSON.parse(profileInfo)).to.be.null;
+    });
+    it("should return profile info, if the user is logged in", async () => {
+      await setLoggedIn();
+      await loadTestPage();
+      const profileInfo = await getProfileInfo();
+      expect(JSON.parse(profileInfo)).to.deep.equal(MockUserProfileInfo.loggedIn);
+    });
+    it("should return a profile with correct email and error status, if the user's login is stale", async () => {
+      await setLoginFailed();
+      await loadTestPage();
+      const profileInfo = await getProfileInfo();
+      expect(JSON.parse(profileInfo)).to.deep.equal(MockUserProfileInfo.error);
+    });
+    it("should return a profile with correct email and error status, if the user's email is unverified", async () => {
+      await setNotVerified();
+      await loadTestPage();
+      const profileInfo = await getProfileInfo();
+      expect(JSON.parse(profileInfo)).to.deep.equal(MockUserProfileInfo.error);
+    });
+  });
+
+  describe("browser.experiments.sync.onUserProfileChanged", () => {
+    it("should notify observers when the internal sync event fires", async () => {
+      // This test simulates two aspects of Firefox Sync code behavior.
+      // In production, when the FxA/Sync state changes, the Firefox Sync code
+      // both updates the UIState, and fires a "sync-ui-state:update" internal
+      // (nsIObserver) event. Note that the Firefox Sync code fires multiple
+      // internal events for a single FxA/Sync state change. The Lockbox sync
+      // API listens for this internal "sync-ui-state:update" event, filters
+      // out duplicate events by comparing the new UIState against the previous
+      // UIState, then notifies onUserProfileChanged observers if the state
+      // has really changed. To test this effectively, we need to both simulate
+      // a legit UIState change, and also fire the "sync-ui-state:update"
+      // event to trigger the update process.
+      await loadTestPage();
+      await registerOnUserProfileChangedListener();
+
+      await setLoggedIn();
+      await refreshUIState();
+      await triggerInternalSyncEvent();
+
+      const events = await getUserProfileChangedEvents();
+      expect(JSON.parse(events)).to.deep.equal([MockUserProfileInfo.loggedIn]);
+    });
+  });
+});

--- a/test/integration/test-pages/sync-api.html
+++ b/test/integration/test-pages/sync-api.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset="utf-8">
+<h1>Sync API Test File</h1>
+<p>This file allows the browser.experiments.sync.* API methods to be
+   called by programmatically clicking buttons. The return values can
+   be checked by looking at the results logged in the named &lt;pre&gt; fields.
+
+<p>Click the Get Profile Info button to add the test login.
+  <button id="get-profile-info">Get Profile Info</button>
+  <pre id="get-profile-info-results"></pre>
+
+<p>Click the Register Listener button to register an onUserProfileChanged listener.
+   Any events will be appended to a list in the results field.
+  <button id="register-listener">Register Listener</button>
+  <pre id="register-listener-results">[]</pre>
+
+  <p>Click the Check Passwords Pref button to check the value of the <pre>services.sync.engine.passwords</pre> preference.
+  <button id="check-passwords-pref">Check Passwords Pref</button>
+  <pre id="check-passwords-pref-results"></pre>
+
+<script src="sync-api.js"></script>

--- a/test/integration/test-pages/sync-api.js
+++ b/test/integration/test-pages/sync-api.js
@@ -1,0 +1,28 @@
+// Returns a function that logs to a DOM element.
+const getLogger = (id) => {
+  return (result) => {
+    let target = document.querySelector(`#${id}-results`);
+    target.textContent = result instanceof Error ? result.toString() : JSON.stringify(result);
+  };
+};
+
+document.querySelector("#get-profile-info").addEventListener("click", () => {
+  const log = getLogger("get-profile-info");
+  browser.experiments.sync.getUserProfileInfo().
+    then(log, log);
+});
+
+document.querySelector("#check-passwords-pref").addEventListener("click", () => {
+  const log = getLogger("check-passwords-pref");
+  browser.experiments.sync.getCurrentState("passwords").
+    then(log, log);
+});
+
+document.querySelector("#register-listener").addEventListener("click", () => {
+  const events = [];
+  const log = getLogger("register-listener");
+  browser.experiments.sync.onUserProfileChanged.addListener(update => {
+    events.push(update);
+    log(events);
+  });
+});


### PR DESCRIPTION
Fixes #23.

## Testing and Review Notes

I've omitted the rethrowing of Errors as `ExceptionError`s in this API, because the underlying code is a lot less likely to throw than LoginManager code was. I can add that boilerplate for consistency with the logins API; comments welcome.

I might have overcomplicated the integration test by extracting the DOM-twiddling code into helper methods. Comments welcome on that point (see the TODO in the file).

For some reason, I'm seeing a "Services is not defined" error when the integration test runs. I've sprinkled extra Services.jsm imports throughout the test, but still haven't tracked down the error. Cleaning that up is a harmless-yet-annoying TODO as well.

Finally, I still need to update the desktop requirements doc to match the changes discussed earlier this week. One further change I've made is to add a `SyncStatus` type, currently either "error" or "ok"; we could change this to expose the two sync errors ("login_failed", stale password error, and "not_verified", unverified email error), or it could just be a boolean and not a separate type. Feedback welcome, and really depends on how this will evolve in the future.

### How to play around with the API:

1. Fire up nightly via `npm run run -- -f nightly`
2. Open up `about:debugging`
3. Click the 'Debug' button to open a debugger
4. In the debugger console, set up your event listener by pasting in this code:

```js
browser.experiments.sync.onUserProfileChanged.addListener(uiState => {
  console.log("onUserProfileChanged fired: ", uiState)
});
```

In the debugger console, you can verify the current Sync/FxA state:

```js
await browser.experiments.sync.getUserProfileInfo();
// should initially return null
```

And you can also verify the state of the pref that controls whether Sync handles the logins saved in the browser (this can be changed by modifying the `sync.engines.passwords` pref directly, or by checking the checkbox in the about:preferences#sync screen):

```js
await browser.experiments.sync.getCurrentState("passwords");
// should initially return true
```

Now you can log in to the browser (hamburger menu > Sign In To Sync), and you'll both see updates from your event listener, as well as be able to query the `getUserProfileInfo` API method to see the state changes.

Note that a first-time login with an unverified email produces an error state. You'll also see a transition to an error state if you log in, then change the FxA password on the FxA website, causing the Firefox login to become stale. The API doesn't distinguish between these two error states right now, because in either case, we'll just send the user to `about:preferences#sync` to fix whatever's wrong.

Error states look like this:

```js
Object {
  id:  "fcea867fcea867fcea867fcea867fcea", 
  email: "jhirsch+asdf@mozilla.com", 
  displayName: null, 
  avatar: null, 
  status: "error" }
```

Verified logins look like this:

```js
{ status: "ok", 
avatar: "https://firefoxusercontent.com/146a19121ec0f71ed250a6a2fc0ff333", 
displayName: "🚨 Cheez Whiz 🚨",
email: "jhirsch+foo@mozilla.com",​
id: "..." }
```
