### PR TITLE
Derive entry titles from saved login URL (#16)

### DIFF
--- a/src/background/datastore.js
+++ b/src/background/datastore.js
@@ -15,7 +15,7 @@ export function convertInfo2Item(info) {
     title = info.hostname;
   }
   title = title.replace(/^http(s)?:\/\//, "").
-                replace(/^www\./, "");
+                replace(/^www\d*\./, "");
 
   const id = info.guid;
   const origins = [ info.hostname, info.formSubmitURL ].

--- a/test/unit/background/datastore-test.js
+++ b/test/unit/background/datastore-test.js
@@ -23,6 +23,53 @@ const LOGINS_EVENTS = [
   "AllRemoved",
 ].map(name => `on${name}`);
 
+const cmpAlphaBy = name => (a, b) => a[name].localeCompare(b[name]);
+
+const SAMPLE_INFOS = {
+  FOO: {
+    guid: "FOO",
+    title: "FOO title",
+    hostname: "https://foo.example.com",
+    httpRealm: null,
+    username: "FOOuser",
+    password: "FOOpass",
+    usernameField: "username",
+    passwordField: "password",
+    timesUsed: 1,
+    timeLastUsed: new Date("2019-01-03T12:00:00Z"),
+    timePasswordChanged: new Date("2019-01-02T12:00:00Z"),
+    timeCreated: new Date("2019-01-01T12:00:00Z"),
+  },
+  BAR: {
+    guid: "BAR",
+    title: "BAR title",
+    hostname: "https://www.bar.example.com",
+    httpRealm: null,
+    username: "BARuser",
+    password: "BARpass",
+    usernameField: "username",
+    passwordField: "password",
+    timesUsed: 0,
+    timeLastUsed: new Date("2019-01-04T12:00:00Z"),
+    timePasswordChanged: new Date("2019-01-03T12:00:00Z"),
+    timeCreated: new Date("2019-01-02T12:00:00Z"),
+  },
+  BAZ: {
+    guid: "BAZ",
+    title: "BAZ title",
+    hostname: "http://baz.example.com",
+    httpRealm: null,
+    username: "BAZuser",
+    password: "BAZpass",
+    usernameField: "username",
+    passwordField: "password",
+    timesUsed: 3,
+    timeLastUsed: new Date("2019-01-05T12:00:00Z"),
+    timePasswordChanged: new Date("2019-01-05T11:00:00Z"),
+    timeCreated: new Date("2019-01-05T10:00:00Z"),
+  },
+};
+
 describe("background > datastore", () => {
   let store;
 
@@ -274,51 +321,38 @@ describe("background > datastore", () => {
     expect(apiRemove.callCount).to.equal(1);
     expect(apiRemove.lastCall.lastArg).to.equal(id);
   });
+
+  describe("hostname to title conversion", () => {
+    let info = Object.assign({}, SAMPLE_INFOS.FOO);
+    it("removes the initial 'https://' part of a hostname", () => {
+      info.hostname = "https://example.com";
+      const item = convertInfo2Item(info);
+      expect(item.title).to.equal("example.com");
+    });
+    it("removes the initial 'http://' part of a hostname", () => {
+      info.hostname = "http://example.com";
+      const item = convertInfo2Item(info);
+      expect(item.title).to.equal("example.com");
+    });
+    it("removes the 'www' subdomain", () => {
+      info.hostname = "http://www.example.com";
+      const item = convertInfo2Item(info);
+      expect(item.title).to.equal("example.com");
+    });
+    it("removes the 'www1' subdomain", () => {
+      info.hostname = "http://www1.example.com";
+      const item = convertInfo2Item(info);
+      expect(item.title).to.equal("example.com");
+    });
+    it("does not remove the 'foo' subdomain", () => {
+      info.hostname = "http://foo.example.com";
+      const item = convertInfo2Item(info);
+      expect(item.title).to.equal("foo.example.com");
+    });
+    it("does not remove the '.com' public suffix", () => {
+      info.hostname = "https://www.example.com";
+      const item = convertInfo2Item(info);
+      expect(item.title.endsWith(".com")).to.be.true;
+    });
+  });
 });
-
-const cmpAlphaBy = name => (a, b) => a[name].localeCompare(b[name]);
-
-const SAMPLE_INFOS = {
-  FOO: {
-    guid: "FOO",
-    title: "FOO title",
-    hostname: "https://foo.example.com",
-    httpRealm: null,
-    username: "FOOuser",
-    password: "FOOpass",
-    usernameField: "username",
-    passwordField: "password",
-    timesUsed: 1,
-    timeLastUsed: new Date("2019-01-03T12:00:00Z"),
-    timePasswordChanged: new Date("2019-01-02T12:00:00Z"),
-    timeCreated: new Date("2019-01-01T12:00:00Z"),
-  },
-  BAR: {
-    guid: "BAR",
-    title: "BAR title",
-    hostname: "https://www.bar.example.com",
-    httpRealm: null,
-    username: "BARuser",
-    password: "BARpass",
-    usernameField: "username",
-    passwordField: "password",
-    timesUsed: 0,
-    timeLastUsed: new Date("2019-01-04T12:00:00Z"),
-    timePasswordChanged: new Date("2019-01-03T12:00:00Z"),
-    timeCreated: new Date("2019-01-02T12:00:00Z"),
-  },
-  BAZ: {
-    guid: "BAZ",
-    title: "BAZ title",
-    hostname: "http://baz.example.com",
-    httpRealm: null,
-    username: "BAZuser",
-    password: "BAZpass",
-    usernameField: "username",
-    passwordField: "password",
-    timesUsed: 3,
-    timeLastUsed: new Date("2019-01-05T12:00:00Z"),
-    timePasswordChanged: new Date("2019-01-05T11:00:00Z"),
-    timeCreated: new Date("2019-01-05T10:00:00Z"),
-  },
-};


### PR DESCRIPTION
Fixes #16.

## Testing and Review Notes

Most of the required logic was already implemented; the only behavior that's been added is filtering out 'www1' or 'www3' subdomains. With this change, the hostname-to-title conversion matches the [Android implementation](https://github.com/mozilla-lockbox/lockbox-android/blob/2669055/app/src/main/java/mozilla/lockbox/model/ModelUtils.kt#L9).

This is a pretty easy one to test: fire up the addon, head into the management page, create a login, play with some different URLs, and see what the item's title turns into after each save. The new unit tests verify behavior in the most common cases.

## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
  - optional: consider adding integration tests
- [x] request the "UX" team perform a design review (if/when applicable)
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
- [x] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-addon/developer/test-plan-accessibility/) of any added UI
