### PR TITLE
Filter out sync logins in event handlers (#67)

### DIFF
--- a/src/experiments/logins/api.js
+++ b/src/experiments/logins/api.js
@@ -18,10 +18,14 @@ ChromeUtils.defineModuleGetter(this, "Services",
 
 const { ExtensionError } = ExtensionUtils;
 
+const isValidLogin = (login) => {
+  return !(login.hostname || "").startsWith("chrome://");
+};
+
 const getLogins = () => {
   const logins = Services.logins.
     getAllLogins().
-    filter((l) => !(l.hostname || "").startsWith("chrome://")).
+    filter(isValidLogin).
     map(LoginHelper.loginToVanillaObject);
   return logins;
 };
@@ -139,6 +143,9 @@ this.logins = class extends ExtensionAPI {
                 }
                 subject.QueryInterface(Ci.nsILoginMetaInfo).QueryInterface(Ci.nsILoginInfo);
                 const login = LoginHelper.loginToVanillaObject(subject);
+                if (!isValidLogin(login)) {
+                  return;
+                }
                 callback({ login });
               },
             };
@@ -159,6 +166,9 @@ this.logins = class extends ExtensionAPI {
                 subject.QueryInterface(Ci.nsIArrayExtensions);
                 const newLoginInfo = subject.GetElementAt(1);
                 const login = LoginHelper.loginToVanillaObject(newLoginInfo);
+                if (!isValidLogin(login)) {
+                  return;
+                }
                 callback({ login });
               },
             };
@@ -178,6 +188,9 @@ this.logins = class extends ExtensionAPI {
                 }
                 subject.QueryInterface(Ci.nsILoginMetaInfo).QueryInterface(Ci.nsILoginInfo);
                 const login = LoginHelper.loginToVanillaObject(subject);
+                if (!isValidLogin(login)) {
+                  return;
+                }
                 callback({ login });
               },
             };

--- a/test/integration/test-pages/logins-api.html
+++ b/test/integration/test-pages/logins-api.html
@@ -32,4 +32,12 @@
   <button id="touch">Touch</button>
   <pre id="touch-results"></pre>
 
+<p>Click the Register Listeners button to register listeners for the onAdded,
+   onUpdated, and onRemoved events. Any events will be appended to a list in
+   the results field. Click the 'Clear results' button to clear the previous
+   results.
+  <button id="register-listeners">Register Listeners</button>
+  <button id="clear-register-listeners-results">Clear results</button>
+  <pre id="register-listeners-results"></pre>
+
 <script src="logins-api.js"></script>

--- a/test/integration/test-pages/logins-api.js
+++ b/test/integration/test-pages/logins-api.js
@@ -55,3 +55,24 @@ document.querySelector("#touch").addEventListener("click", () => {
   browser.experiments.logins.touch(mockLogin.guid).
     then(log, log);
 });
+
+const events = [];
+document.querySelector("#register-listeners").addEventListener("click", () => {
+  const log = getLogger("register-listeners");
+  const makeEventHandler = (eventName) => {
+    return (login) => {
+      events.push([eventName, login]);
+      log(events);
+    };
+  };
+  browser.experiments.logins.onAdded.addListener(makeEventHandler("onAdded"));
+  browser.experiments.logins.onUpdated.addListener(makeEventHandler("onUpdated"));
+  browser.experiments.logins.onRemoved.addListener(makeEventHandler("onRemoved"));
+});
+document.querySelector("#clear-register-listeners-results").addEventListener("click", () => {
+  const log = getLogger("register-listeners");
+  while (events.length) {
+    events.pop();
+  }
+  log(events);
+});


### PR DESCRIPTION
Fixes #67

## Testing and Review Notes

You can verify this change does what it should by signing into sync and looking at the Lockbox doorhanger with and without this patch applied.

Without this patch applied, if you sign in to sync, the Lockbox UI will show a login with the odd URL `chrome://FirefoxAccounts`. It turns out that this is a special Sync/FxA login that is filtered out by logic in the `getLogins()` function, but the filtering wasn't being applied when Firefox-internal login change events fired.

This PR adds filtering to the `onUpdated`, `onAdded`, and `onRemoved` event handlers in the logins API.

This PR also adds tests for the events in the Logins API, verifying that the appropriate event is fired when a regular login is added, updated, or removed, and also verifying that no event is fired when the FxA/Sync login is similarly added, updated, or removed.

The integration tests are a bit wordy, but I'm not sure how to reduce duplication without impacting readability. Suggestions welcome :beers: