### PR TITLE
Disable prompts to save logins while on extension pages

### DIFF
--- a/src/background/environment.js
+++ b/src/background/environment.js
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export async function initializeEnvironment() {
+  // Issue #57: Disable login saving for extension pages.
+  const origin = browser.extension.getURL("").slice(0, -1);
+  const savingEnabled = await browser.experiments.logins
+    .getLoginSavingEnabled(origin);
+  if (savingEnabled) {
+    await browser.experiments.logins
+      .setLoginSavingEnabled(origin, false);
+  }
+}

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -8,8 +8,10 @@ import updateBrowserAction from "./browser-action";
 import initializeMessagePorts from "./message-ports";
 import { initializeTelemetry } from "./telemetry";
 import { initializeDataStore } from "./datastore";
+import { initializeEnvironment } from "./environment";
 
 Promise.resolve().then(async () => {
+  await initializeEnvironment();
   initializeTelemetry();
   initializeMessagePorts();
   await initializeDataStore();

--- a/src/experiments/logins/api.js
+++ b/src/experiments/logins/api.js
@@ -49,6 +49,20 @@ this.logins = class extends ExtensionAPI {
           //   - fooLogin = login as vanilla JS object
           //   - fooLoginInfo = login as nsILoginInfo
           //   - fooBag = (subset of) login fields as nsIPropertyBag
+          getLoginSavingEnabled(origin) {
+            try {
+              return Services.logins.getLoginSavingEnabled(origin);
+            } catch (ex) {
+              throw new ExtensionError(ex);
+            }
+          },
+          setLoginSavingEnabled(origin, isEnabled) {
+            try {
+              return Services.logins.setLoginSavingEnabled(origin, isEnabled);
+            } catch (ex) {
+              throw new ExtensionError(ex);
+            }
+          },
           getAll() {
             const logins = getLogins();
             return logins;

--- a/src/experiments/logins/schema.json
+++ b/src/experiments/logins/schema.json
@@ -200,6 +200,32 @@
     ],
     "functions": [
       {
+        "name": "getLoginSavingEnabled",
+        "type": "function",
+        "description": "Reports whether or not saving login information is enabled for a host.",
+        "async": true,
+        "parameters": [{
+          "name": "aHost",
+          "type": "string",
+          "description": "The origin for which to check the status of login saving"
+        }]
+      },
+      {
+        "name": "setLoginSavingEnabled",
+        "type": "function",
+        "description": "Enables or disables storing logins for a specified host. When login storing is disabled, the Login Manager won't prompt the user to store logins for that host. Existing logins are not affected.",
+        "async": true,
+        "parameters": [{
+          "name": "aHost",
+          "type": "string",
+          "description": "The origin for which to modify the login saving permission"
+        },{
+          "name": "isEnabled",
+          "type": "boolean",
+          "description": "The value to which to set login saving for the origin"
+        }]
+      },
+      {
         "name": "getAll",
         "type": "function",
         "description": "Gets an array of all Logins. Returns a Promise for the (possibly empty) list of all Logins.",

--- a/test/integration/test-pages/logins-api.html
+++ b/test/integration/test-pages/logins-api.html
@@ -40,4 +40,10 @@
   <button id="clear-register-listeners-results">Clear results</button>
   <pre id="register-listeners-results"></pre>
 
+<p>Click the Enable / Disable buttons to change login saving permission for
+   this extension</p>
+  <button id="enable-saving">Enable Saving</button>
+  <button id="disable-saving">Disable Saving</button>
+  <pre id="saving-results"></pre>
+
 <script src="logins-api.js"></script>

--- a/test/integration/test-pages/logins-api.js
+++ b/test/integration/test-pages/logins-api.js
@@ -76,3 +76,18 @@ document.querySelector("#clear-register-listeners-results").addEventListener("cl
   }
   log(events);
 });
+
+const changeSaving = val => {
+  const origin = window.location.origin;
+  const log = getLogger("saving");
+  browser.experiments.logins
+    .setLoginSavingEnabled(origin, val)
+    .then(() =>
+      browser.experiments.logins
+        .getLoginSavingEnabled(origin))
+    .then(log, log);
+};
+document.querySelector("#enable-saving")
+  .addEventListener("click", () => changeSaving(true));
+document.querySelector("#disable-saving")
+  .addEventListener("click", () => changeSaving(false));

--- a/test/unit/background/environment-test.js
+++ b/test/unit/background/environment-test.js
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { expect } from "chai";
+import sinon from "sinon";
+
+import "test/unit/mocks/browser";
+
+import {
+  initializeEnvironment,
+} from "src/background/environment";
+
+describe("background > environment", () => {
+  it("disables login saving for extension pages", async () => {
+    sinon
+      .stub(browser.experiments.logins, "getLoginSavingEnabled")
+      .resolves(true);
+    sinon
+      .stub(browser.experiments.logins, "setLoginSavingEnabled")
+      .resolves(undefined);
+    sinon
+      .stub(browser.extension, "getURL")
+      .returns("moz-extension://8675309/");
+
+    await initializeEnvironment();
+
+    expect(browser.experiments.logins.getLoginSavingEnabled.called).to.be.true;
+    expect(browser.experiments.logins.setLoginSavingEnabled.called).to.be.true;
+
+    const args = browser.experiments.logins.setLoginSavingEnabled.firstCall.args;
+    expect(args[0]).to.equal("moz-extension://8675309");
+    expect(args[1]).to.equal(false);
+
+    browser.experiments.logins.getLoginSavingEnabled.restore();
+    browser.experiments.logins.setLoginSavingEnabled.restore();
+    browser.extension.getURL.restore();
+  });
+});

--- a/test/unit/mocks/browser.js
+++ b/test/unit/mocks/browser.js
@@ -197,6 +197,8 @@ window.browser = {
 
   experiments: {
     logins: {
+      async getLoginSavingEnabled() { },
+      async setLoginSavingEnabled() { },
       async getAll() { return []; },
       async add(login) {
         browser.experiments.logins.onAdded.getListener()({ login });


### PR DESCRIPTION
- Add getLoginSavingEnabled and setLoginSavingEnabled methods to the
  Logins experiment API

- Disable login saving for extension pages on background startup

Fixes #57
