### PR TITLE
Updated Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Firefox Lockbox for Desktop
 
-The Android application repository for [Firefox Lockbox][org-website].
+The Firefox Addon repository for [Firefox Lockbox][org-website].
 
 ## [Documentation][docs-link]
 


### PR DESCRIPTION
This is the repo for the Firefox Addon, not the android app.

Fixes referencing the wrong part of Lockbox in the readme for this repo.