### PR TITLE
32 manage page list styles

### DIFF
--- a/src/icons/add-icon.svg
+++ b/src/icons/add-icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 14 14">
+    <path fill="#F9F9FA" fill-rule="nonzero" d="M13 6H8V1a1 1 0 1 0-2 0v5H1a1 1 0 1 0 0 2h5v5a1 1 0 0 0 2 0V8h5a1 1 0 0 0 0-2z"/>
+</svg>

--- a/src/list/components/item-list.css
+++ b/src/list/components/item-list.css
@@ -34,8 +34,7 @@
 
 .item[data-selected] .item-summary {
   position: relative;
-  background-color: #e7e7e7;
-  box-shadow: 0 -1px 0 #e7e7e7, 0 1px 0 #e7e7e7;
+  background-color: #ededf0;
   cursor: pointer;
 }
 
@@ -54,7 +53,7 @@
   right: 0;
   width: 100%;
   height: 1px;
-  background-color: #99bff2;
+  background-color: #d7d7db;
   z-index: 10;
 }
 
@@ -66,7 +65,24 @@
   bottom: -1px;
 }
 
-.item-list:focus .item[data-selected] .item-summary::before,
-.item-list:focus .item[data-selected] .item-summary::after {
+/* Stick with the pseudoelement pattern for the big blue left border for the
+   selected item. Give it a higher z-index than the top/bottom borders, so
+   the blue bar is the full height of the item, matching the mocks. */
+
+.item[data-selected] {
+  position: relative;
+}
+
+.item[data-selected]::before {
+  content: "";
+  display: block;
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
   background-color: #0a84ff;
+  z-index: 11;
+  margin-top: -1px;
+  margin-bottom: -1px;
 }

--- a/src/list/components/item-summary.css
+++ b/src/list/components/item-summary.css
@@ -20,6 +20,10 @@
   width: 9px;
 }
 
+.info.new-item {
+  background-image: none;
+}
+
 .info.panel {
   right: 0px;
   top: -3px;

--- a/src/list/components/item-summary.css
+++ b/src/list/components/item-summary.css
@@ -20,7 +20,7 @@
   width: 9px;
 }
 
-.info.new-item {
+li[data-selected] .info {
   background-image: none;
 }
 

--- a/src/list/components/item-summary.css
+++ b/src/list/components/item-summary.css
@@ -12,7 +12,15 @@
 }
 
 .info {
+  background: url(/icons/chevron-right.svg) no-repeat;
   position: absolute;
+  right: 12px;
+  top: 25px;
+  height: 9px;
+  width: 9px;
+}
+
+.info.panel {
   right: 0px;
   top: -3px;
   width: 18px;
@@ -27,11 +35,11 @@
   border-radius: 2px;
 }
 
-.info:hover {
+.info.panel:hover {
   background-color: rgba(12, 12, 13, 0.1);
 }
 
-.item-summary:hover .info {
+.item-summary:hover .info.panel {
   background-image: url(/icons/info-dark.svg);
 }
 

--- a/src/list/components/item-summary.js
+++ b/src/list/components/item-summary.js
@@ -30,7 +30,7 @@ export default function ItemSummary({className, id, title, username, panel}) {
                    $length={trimmedUsername.length}>
           <div data-name="subtitle" className={styles.subtitle}>no uSERNAMe</div>
         </Localized>
-        {panel && <span className={styles.info}></span>}
+        <span className={`${styles.info} ${panel ? styles.panel : null}`}></span>
       </div>
     </div>
   );

--- a/src/list/components/item-summary.js
+++ b/src/list/components/item-summary.js
@@ -31,7 +31,9 @@ export default function ItemSummary({className, id, title, username, panel}) {
                    $length={trimmedUsername.length}>
           <div data-name="subtitle" className={styles.subtitle}>no uSERNAMe</div>
         </Localized>
-        <span className={`${styles.info} ${panel ? styles.panel : null} ${isNew ? styles.newItem : null}`}></span>
+        {!isNew &&
+           <span className={classNames([styles.info, panel ? styles.panel : ""])}></span>
+        }
       </div>
     </div>
   );

--- a/src/list/components/item-summary.js
+++ b/src/list/components/item-summary.js
@@ -16,7 +16,8 @@ export default function ItemSummary({className, id, title, username, panel}) {
   const trimmedTitle = title.trim();
   const trimmedUsername = username.trim();
 
-  const idModifier = id === NEW_ITEM_ID ? "new-" : "";
+  const isNew = id === NEW_ITEM_ID;
+  const idModifier = isNew ? "new-" : "";
   const titleId = `item-summary-${idModifier}title`;
   const usernameId = `item-summary-${idModifier}username`;
   return (
@@ -30,7 +31,7 @@ export default function ItemSummary({className, id, title, username, panel}) {
                    $length={trimmedUsername.length}>
           <div data-name="subtitle" className={styles.subtitle}>no uSERNAMe</div>
         </Localized>
-        <span className={`${styles.info} ${panel ? styles.panel : null}`}></span>
+        <span className={`${styles.info} ${panel ? styles.panel : null} ${isNew ? styles.newItem : null}`}></span>
       </div>
     </div>
   );

--- a/src/list/manage/components/item-list-panel.css
+++ b/src/list/manage/components/item-list-panel.css
@@ -10,3 +10,7 @@
   composes: panel-header from "../../../widgets/panel.css";
   background: #fff;
 }
+
+.item-filter {
+  background: #f3f3f5;
+}

--- a/src/list/manage/components/item-list-panel.css
+++ b/src/list/manage/components/item-list-panel.css
@@ -5,3 +5,8 @@
 .filter-toolbar > * + * {
   margin-inline-start: 8px;
 }
+
+.panel-header {
+  composes: panel-header from "../../../widgets/panel.css";
+  background: #fff;
+}

--- a/src/list/manage/components/item-list-panel.css
+++ b/src/list/manage/components/item-list-panel.css
@@ -12,5 +12,7 @@
 }
 
 .item-filter {
+  composes: item-filter from "../../../widgets/panel.css";
   background: #f3f3f5;
+  height: 32px;
 }

--- a/src/list/manage/components/item-list-panel.js
+++ b/src/list/manage/components/item-list-panel.js
@@ -36,7 +36,8 @@ export default function ItemListPanel({className, inputRef, totalItemCount,
       <PanelHeader className={styles.panelHeader}
                    border={hasItems ? "floating" : "none"}
                    toolbarClassName={styles.filterToolbar}>
-        <ItemFilter inputRef={inputRef}/>
+        <ItemFilter className={styles.itemFilter}
+                    inputRef={inputRef}/>
         <AddItem/>
       </PanelHeader>
 

--- a/src/list/manage/components/item-list-panel.js
+++ b/src/list/manage/components/item-list-panel.js
@@ -6,11 +6,10 @@ import { Localized } from "fluent-react";
 import PropTypes from "prop-types";
 import React from "react";
 
-import { PanelHeader, PanelBody, PanelFooter } from "../../../widgets/panel";
+import { PanelHeader, PanelBody } from "../../../widgets/panel";
 import AddItem from "../containers/add-item";
 import ItemList, { ItemListPlaceholder } from "../../components/item-list";
 import ItemFilter from "../../containers/item-filter";
-import SendFeedback from "../containers/send-feedback";
 
 import styles from "./item-list-panel.css";
 
@@ -44,10 +43,6 @@ export default function ItemListPanel({className, inputRef, totalItemCount,
       <PanelBody scroll={false}>
         {list}
       </PanelBody>
-
-      <PanelFooter border="floating">
-        <SendFeedback/>
-      </PanelFooter>
     </aside>
   );
 }

--- a/src/list/manage/components/item-list-panel.js
+++ b/src/list/manage/components/item-list-panel.js
@@ -33,7 +33,8 @@ export default function ItemListPanel({className, inputRef, totalItemCount,
 
   return (
     <aside className={className}>
-      <PanelHeader border={hasItems ? "floating" : "none"}
+      <PanelHeader className={styles.panelHeader}
+                   border={hasItems ? "floating" : "none"}
                    toolbarClassName={styles.filterToolbar}>
         <ItemFilter inputRef={inputRef}/>
         <AddItem/>

--- a/src/list/manage/containers/add-item.js
+++ b/src/list/manage/containers/add-item.js
@@ -13,11 +13,14 @@ import { startNewItem } from "../../actions";
 import styles from "./add-item.css";
 
 function AddItem({disabled, onAddItem}) {
+  const imgSrc = browser.extension.getURL("/icons/add-icon.svg");
   return (
-    <Localized id="add-item-button">
-      <Button theme="primary" id="addItemButton" className={styles.addItem} disabled={disabled}
+    <Localized id="add-item-button" attrs={{
+      "title": true,
+    }}>
+      <Button theme="primary" title="nEW eNTRy" id="addItemButton" className={styles.addItem} disabled={disabled}
               onClick={onAddItem}>
-        aDd iTEm
+        <img src={imgSrc} />
       </Button>
     </Localized>
   );

--- a/src/list/popup/components/item-list-panel.css
+++ b/src/list/popup/components/item-list-panel.css
@@ -2,10 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-.panel-body {
-  background: #F2F2F4;
-}
-
 .panel-footer-button {
   color: #f9f9fa;
   cursor: pointer;

--- a/src/locales/en-US/list.ftl
+++ b/src/locales/en-US/list.ftl
@@ -28,14 +28,14 @@ item-fields-copy-password =
   .title = Copy the password to the clipboard
 item-fields-notes = Notes
 
-item-summary-new-title = New entry
+item-summary-new-title = New Entry
 item-summary-title =
   { $length ->
      [0]     (no site name)
     *[other] { $title }
   }
 
-item-summary-new-username = (enter your login details)
+item-summary-new-username = Enter your login credentials
 item-summary-username =
   { $length ->
      [0]     (no username)

--- a/src/locales/en-US/list.ftl
+++ b/src/locales/en-US/list.ftl
@@ -48,8 +48,8 @@ item-summary-copy-password = Copy Password
   .title = Copy the password to the clipboard
 
 item-filter =
-  .placeholder = Search Logins
-  .aria-label = Search Logins
+  .placeholder = Search Lockbox
+  .aria-label = Search Lockbox
 
 ## manage
 

--- a/src/locales/en-US/list.ftl
+++ b/src/locales/en-US/list.ftl
@@ -53,7 +53,7 @@ item-filter =
 
 ## manage
 
-add-item-button = +
+add-item-button =
   .title = New entry
 
 send-feedback-button = Provide Feedback

--- a/src/locales/fr-FR/list.ftl
+++ b/src/locales/fr-FR/list.ftl
@@ -53,7 +53,7 @@ item-filter =
 
 ## manage
 
-add-item-button = +
+add-item-button =
   .title = Nouvel enregistrement
 
 send-feedback-button = Fournir retour utilisateur

--- a/src/locales/fr-FR/list.ftl
+++ b/src/locales/fr-FR/list.ftl
@@ -49,6 +49,7 @@ item-summary-copy-password = Copier Mot de passe
 
 item-filter =
   .placeholder = Recherche Lockbox
+  .aria-label = Recherche Lockbox
 
 ## manage
 

--- a/src/widgets/input.css
+++ b/src/widgets/input.css
@@ -40,6 +40,11 @@ input::placeholder {
   border-color: rgba(12, 12, 13, 0.5);
 }
 
+.input:not([disabled]):focus,
+.input-wrapper:not(.disabled):focus-within {
+  border-color: #0a84ff;
+}
+
 .input-wrapper {
   display: flex;
 }

--- a/src/widgets/input.css
+++ b/src/widgets/input.css
@@ -52,7 +52,7 @@ input::placeholder {
 .input-wrapper > input {
   flex: 1;
   padding: 0 8px;
-  font-size: 13px;
+  font-size: 15px;
   width: 0;
   min-width: 0;
   border: 0;
@@ -90,7 +90,7 @@ input::placeholder {
   /* This lines up our labels with the text in <input> elements. */
   margin-top: 7px;
   min-height: 25px;
-  font-size: 13px;
+  font-size: 15px;
   font-weight: bold;
   -moz-user-select: text;
   overflow: hidden;

--- a/src/widgets/input.css
+++ b/src/widgets/input.css
@@ -17,7 +17,6 @@
   width: -moz-available;
   background-color: #ffffff;
   border: 1px solid rgba(12, 12, 13, 0.3);
-  border-radius: 2px;
 }
 
 .input[disabled],

--- a/src/widgets/input.css
+++ b/src/widgets/input.css
@@ -32,7 +32,7 @@
 }
 
 input::placeholder {
-  color: #737373;
+  color: #4a4a4f;
 }
 
 .input:not([disabled]):hover,

--- a/src/widgets/panel.css
+++ b/src/widgets/panel.css
@@ -62,7 +62,7 @@
   flex: 1;
   display: grid;
   overflow: hidden;
-  background-color: #ededf0;
+  background-color: #f2f2f4;
 }
 
 .panel-body.scroll {

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -10,5 +10,8 @@ module.exports = {
   rules: {
     "font-family-no-missing-generic-family-keyword": null,
     "no-descending-specificity": null,
+    "property-no-unknown": [true, {
+      "ignoreProperties": ["composes"],
+    }],
   },
 };


### PR DESCRIPTION
Fixes #32

## Testing and Review Notes

Visual updates based on the zeplin mocks linked in #32.

This PR should only impact the management page list view; watch out for unexpected changes to the panel list view.

Questions for dev: 

- commit e09991e: I'm not crazy about the amount of panel vs page special case code in here, but it works; suggestions welcome. 
- Also in this same commit, I went with the positioned span approach for the right chevron shown in the list items, but based on the use of pseudoelements for list separators (which I adopted for the blue left-side border in commit b27aee8), it kinda seems like an ::after element would be a better option for both the right chevron and the info icon (in the panel list item view). However, item-summary already has the top/bottom border pseudoelements, and I wasn't sure whether it would be a net gain to add yet another wrapper element vs. just rolling with the current positioned span. 

Question for UX:

I wasn't clear on the differences between hover, focus, and active states, based on the zeplin mocks. I'm particularly curious if these three states look correct for the list item, the search field, and the '+' button.

## Screenshots or Videos

I'm going to skip these, to encourage reviewers to actually exercise the code a bit (afraid I'm missing some edge cases)...but if this seems a little too lazy on my part, I can add side-by-side screenshots for comparison purposes 🙃

