### PR TITLE
edit metrics doc

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -79,7 +79,7 @@ Services.telemetry.registerEvents("event_category", {
 For our purposes, we will use the `extra` field for a few purposes:
 
 - To log the UUID of the item that has been added or changed (e.g. `"item_id": UUID`)
-- To log the fields that are modified when an item is updated in the datastore (e.g. `"fields": "username,passsword,address"` (because the value has to be a string we will have to concat the fields that were updated somehow)
+- To log the fields that are modified when an item is updated in the datastore (e.g. `"fields": "username,passsword,hostname"` (because the value has to be a string we will have to concat the fields that were updated somehow)
 
 Once an event is registered, we can record it with:
 
@@ -131,9 +131,9 @@ All events are currently implemented under the **category: lockbox-addon**. The 
 
 1. `startup` fires when the webextension is loaded. **objects**: webextension. Note that this event fires whenever the browser is started, so is not indicative of direct user interaction with Lockbox. **value** is null.
 
-2. `click` fires when someone clicks on one of the UI elements listed **objects**: `toolbar`, `get_mobile`, `faq`, `account_settings`, `give_feedback`, `settings_menu` (or whatever the menu is that contains links to account settings, faq, etc). **value** is null.
+2. `click` fires when someone clicks on one of the UI elements listed **objects**: `toolbar`, `get_mobile`, `faq`, `account_settings`, `give_feedback`, `settings_menu`, `reconnect_sync`, `signin_sync` (or whatever the menu is that contains links to account settings, faq, etc). **value** is null.
 
-3. `show` events fire when various UI elements are rendered shown to the user. **objects**: `item_list_manager`, `item_list_doorhanger`, `item_detail_doorhanger` `item_detail_manager`, `new_item`, `item_edit`, `delete_confirm`, `connect_another_device`, `reconnect_sync` **value** should be a boolean for `item_list_*` events indicating whether any logins are in the login list (e.g. `False` if the list is empty).
+3. `show` events fire when various UI elements are rendered shown to the user. **objects**: `item_list_manager`, `item_list_doorhanger`, `item_detail_doorhanger` `item_detail_manager`, `new_item`, `item_edit`, `delete_confirm`, `connect_another_device` (referring to the dialog displayed after a user clicks on the button to learn about the mobile apps) **value** should be a boolean for `item_list_*` events indicating whether any logins are in the login list (e.g. `False` if the list is empty).
 
 4. `item_add`, `item_update`, `item_delete` fire after a successful adding, editing or deleting of a credential. **objects**: manager, doorhanger (contingent on where the user initiated the action). item GUID should be in the extra field. **value** is null
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -62,13 +62,13 @@ The events that we will record will conform to the structure expected by the tel
 The API takes care of the timestamp for us. We just need to define `category`, `method`, `object` and `extra` (`value` is optional and we won't use it).
 
 
-Events are defined by **registering** them using a call to `Services.telemetry.registerEvents(category, eventData)`.
+Events are defined by **registering** them using a call to `browser.telemetry.registerEvents(category, eventData)`.
 
 Here's a breakdown of how a to register a typical event:
 
 
 ```javascript
-Services.telemetry.registerEvents("event_category", {
+browser.telemetry.registerEvents("event_category", {
     "event_name": {
         methods: ["click", ... ], // types of events that can occur
         objects: ["a_button", ... ], // objects event can occur on
@@ -83,7 +83,7 @@ For our purposes, we will use the `extra` field for a few purposes:
 
 Once an event is registered, we can record it with:
 
-`Services.telemetry.recordEvent(category, method, object, value, extra)`
+`browser.telemetry.recordEvent(category, method, object, value, extra)`
 
 Note: The semantics of `value` is contingent on the event being recorded, see list below.
 
@@ -94,9 +94,9 @@ See the Events section for specific examples of event registration and recording
 We use the js api for scalar recording as well. Here registration happens with the following syntax:
 
 ```javascript
-Services.telemetry.registerScalars(category, {
+browser.telemetry.registerScalars(category, {
 	"scalar_name": {
-		kind: services.Telemetry.SCALAR_TYPE_COUNT, // SCALAR_TYPE_COUNT, SCALAR_TYPE_BOOLEAN. or SCALAR_TYPE_STRING
+		kind: browser.Telemetry.SCALAR_TYPE_COUNT, // SCALAR_TYPE_COUNT, SCALAR_TYPE_BOOLEAN. or SCALAR_TYPE_STRING
 		keyed: false,
 		record_on_release: false, // NEEDS TO BE SET TO RECORD ON RELEASE CHANNEL
 		expired: false,
@@ -105,7 +105,7 @@ Services.telemetry.registerScalars(category, {
 We set scalar values in the following way:
 
 ```javascript
-Services.telemetry.scalarSet(
+browser.telemetry.scalarSet(
 	"category.scalar_name", value
 );
 ```
@@ -117,13 +117,10 @@ We can also use `scalarAdd` to increment a scalar value by some amount.
 
 These are the metrics we currently collect regarding the state of the user's login storage.
 
-- `loginCount` (SCALAR_TYPE_COUNT). Current count of the number of items in the user's login storage. If possible, this scalar should be set upon opening either the doorhanger or full extension interface.
+- `loginCount` (SCALAR_TYPE_COUNT). Current count of the number of items in the user's login storage. If possible, this scalar should be set upon opening either the doorhanger or full extension interface. It need not be set "in the background" in the absence of any user interaction with the app.
 
-- `loginsAccessedAllTime` (SCALAR_TYPE_COUNT). Running total of logins accessed (copied, revealed) through the extension interface or doorhanger. Should never be reset.
+- `loginsAccessed` (SCALAR_TYPE_COUNT). Total of logins accessed (copied, revealed) during the last telemetry session.
 
-- `loginsAccessed` (SCALAR_TYPE_COUNT). Total of logins accessed (copied, revealed) since last ping through the extension interface or doorhanger. TODO: in native code scalars are automatically reset when a new ping is cut. Will that happen for us?
-
-Note that if the preceding two scalars are going to cause engineering headaches its possible to obtain equivalent values from the event telemetry (its just more work).
 
 ## List of Planned Metrics Events
 
@@ -139,11 +136,11 @@ All events are currently implemented under the **category: lockbox-addon**. The 
 
 5. `item_selected` fires when a user clicks an item in the itemlist. **objects** manager, doorhanger  **value** is null
 
-6. `copy_password` and `copy_username` fire when a user copies their username or password from an item. **objects**: `item_detail_manager`, `item_detail_doorhanger` **value** is null
+6. `copy_password` and `copy_username` fire when a user copies their username or password from an item. **objects**: `item_detail_manager`, `item_detail_doorhanger` **value** is null. item GUID should be in the extra field.
 
-7. `reveal_password` fires when a user reveals a password from within the item detail view. **objects**: `item_detail_manager`, `item_detail_doorhanger` **value** is null
+7. `reveal_password` fires when a user reveals a password from within the item detail view. **objects**: `item_detail_manager`, `item_detail_doorhanger` **value** is null item GUID should be in the extra field.
 
-8. `open_website` fires when a user clicks to open a credential's associated web address. **objects**: `item_detail_manager`, `item_detail_doorhanger` **value** is null
+8. `open_website` fires when a user clicks to open a credential's associated web address. **objects**: `item_detail_manager`, `item_detail_doorhanger` **value** is null item GUID should be in the extra field.
 
 
 
@@ -152,6 +149,6 @@ All events are currently implemented under the **category: lockbox-addon**. The 
 
 ## References
 
-Docs for the Public JS API that allows us to log events thru an add-on:
+Docs for the Mozilla privileged JS API that allows us to log events thru an add-on:
 
 [Telemetry Public JS API](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/events.html#the-api)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,6 +1,6 @@
-# Lockbox Metrics Plan
+# Lockbox Desktop Addon Metrics Plan
 
-_Last Updated: Feb 19, 2018_
+_Last Updated: Feb 19, 2019_
 
 <!-- TOC depthFrom:2 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
 
@@ -8,64 +8,50 @@ _Last Updated: Feb 19, 2018_
 - [Collection](#collection)
 	- [Event Registration and Recording](#event-registration-and-recording)
 - [Scalar Metrics](#scalar-metrics)
-- [List of Events Currently Recorded](#list-of-events-currently-recorded)
+- [List of Planned Metrics Events](#list-of-planned-metrics-events)
 - [References](#references)
 
 <!-- /TOC -->
 
 This is the metrics collection plan for Lockbox. It documents all events currently collected through telemetry, as well those planned for collection but not currently implemented. It will be updated periodically to reflect all new and planned data collection.
 
+For similar docs relating to data collection on other platforms see [iOS](https://github.com/mozilla-lockbox/lockbox-ios/blob/master/docs/metrics.md) and [Android](https://github.com/mozilla-lockbox/lockbox-android/blob/master/docs/metrics.md).
+
 ## Analysis
 
-Data collection is done solely for the purpose of product development, improvement and maintenance. Specifically, it is done to help its creators examine the validity of the following hypothesis.
+Data collection is done solely for the purpose of product development, improvement and maintenance.
 
-Core Hypothesis: **We believe that people want the browser to do more than only remember their passwords.**
+The data collection outlined here is geared toward answering the following questions (see [List of Implemented Events](#list-of-planned-metrics-events):
 
-We will know this to be true when:
+*Note that when we refer to retrieval of "credentials", we mean access to usernames, passwords, or both*
 
-1. The password generator is clicked 20% of the time a new entry is created. **This will indicate that users value the ability to create secure passwords.** (Events regarding password generation will be added when feature development is complete)
+* Are users using Lockbox to retrieve credentials?
+	* For different intervals of time (e.g. day, week, month), what is:
+		* The average rate with which a user retrieves a credential or reveals a password
+		* The distribution of above rates across all users
+* Does adoption of Lockbox lead to adoption of the associated Lockbox Mobile Apps?
+* Once downloaded, do users continue to use the app? (i.e., how well are they retained?)
+	* We will count a user as retained in a given time interval if they perform one of the following actions:
+		* Display the credential list
+		* Tap a credential in the credential list
+		* Copy a credential to the clipboard
+		* Reveal a password
+		* Autofill a credential stored in Lockbox into another app
+		* Tap the URI associated with a credential (to open it in an app or browser)
+	* Since they can be performed automatically, we will **not** count a user as retained if they *only* perform the following actions (in absence of any in the list above):
+		* Unlock their credentials
+		* Sync their credentials from the Firefox desktop browser
+* Does requiring a Firefox Account constitute a roadblock to adoption?
+	* What proportion of new Lockbox users are pre-existing Firefox Account users?
+	* What proportion of users start the Account sign-in process but never complete it?
 
-2. 75% of Lockbox downloads result in a Firefox account attached. **This will indicate that users value secure storage for their credentials.** We currently record the event `fxaUpgrade` to know whether a user has attached an Firefox account to their lockbox installation.
-
-3. 60% of users choose to import their existing credentials from Firefox into Lockbox. **This will indicate that users trust lockbox more than the browser for managing their credentials.** (Events regarding the importing of credentials from the firefox password manager will be added when feature development is complete)
-
-4. We observe increased engagement with the management system (Create-Read-Update-Delete; CRUD) for users that import their credentials. **This will indicate that users value greater visibility into the number of accounts that they have.** We currently record `render` events when a user opens the credential manager.
-
-5. CRUD usage rates are comparable to Firefox login manager usage prior to lockbox installation. **This will indicate that users value Lockbox's credential management system, and use it to access credentials when they are needed.** Firefox telemetry currently collects data on password autofill usage, which requires credentials be stored in the firefox password manager. We plan to compare lockbox credential usage (e.g. via the `usernameCopied` and `passwordCopied` lockbox events) to pre-lockbox autofill frequencies on a per-user basis.
-
-6. 20% of Lockbox users access their datastore on more than 1 device, **indicating that users value having a single datastore of credentials.**
-
-
-Other questions we aim to answer through data collection, but are not directly related to the hypothesis above:
-
-- Do people Save Passwords in Lockbox?
-	- How many? (measured by count of items saved per user)
-	- How often? (number of credentials saved per user per time interval)
-- Do people create their own passwords or use Lockbox to generate them?
-	- Ratio: (Number of times the PW generator is used when storing an item) / (number of credentials stored)
-- When using the pw generator, do people create purely random passwords or customize them with their own input? (if this is going to be in the final design)
-- Do people use the passwords they store on Lockbox?
-	- How many times (per some unit of time) do stored credentials get filled?
-	- How many times (per some unit of time) do stored credentials get copied?
-- How many times do users click to reveal a password?
-- Do people continue to use Lockbox after first use?
-	- Out of those who install, how many use it more than once?
-- Where are the drop-off points in the user flow?
-	- Do the majority of people make it all the way through the setup process?
-	- Once initially setup, do people continue to add credentials?
-- Do people sync their passwords between Firefox instances?
-	- How does syncing affect engagement?
-
+In addition to answering the above questions that directly concern actions in the app, we will also analyze telemetry emitted from the native password manager that exist in the the Firefox desktop browser. Users of the extension should not be having to use the native manager, so data suggesting otherwise may be a sign that something is amiss.
 
 ## Collection
 
-At this point, all measurements related to Lockbox will be made client-side. However, future releases will give users the option to sync their Lockbox data via an FxA account, at which point additional measurements will be logged server-side through the FxA data pipeline. We are not directly responsible for the measurements made through that mechanism.
+To record Telemetry we will be making use of the public JavaScript API that allows recording and sending of [events](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/events.html#public-js-api) and [scalar measurements](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/scalars.html#js-api) through a webextension.
 
-For our internal alpha release, we will be making use of the public JavaScript API that allows recording and sending of event data and scalar data through an add-on. The API is documented here:
-
-https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/events.html#the-api
-
-Once events are logged in the client they should appear in [about:telemetry](about:telemetry). From there they will be submitted in the main ping payload under `processes.dynamic.events` and available through the usual services (STMO and ATMO), as well as amplitude.
+Once telemetry is logged on the measurements should appear in [about:telemetry](about:telemetry). From there they will be submitted in the main ping payload under `processes.dynamic.events` and available through the usual services (STMO and ATMO), as well as amplitude (eventually).
 
 ### Event Registration and Recording
 
@@ -75,9 +61,8 @@ The events that we will record will conform to the structure expected by the tel
 
 The API takes care of the timestamp for us. We just need to define `category`, `method`, `object` and `extra` (`value` is optional and we won't use it).
 
-Because we are using the API through an add-on it **isn't** necessary that we include an events.yaml file.
 
-Instead we will define our events by **registering** them using a call to `Services.telemetry.registerEvents(category, eventData)`.
+Events are defined by **registering** them using a call to `Services.telemetry.registerEvents(category, eventData)`.
 
 Here's a breakdown of how a to register a typical event:
 
@@ -94,13 +79,13 @@ Services.telemetry.registerEvents("event_category", {
 For our purposes, we will use the `extra` field for a few purposes:
 
 - To log the UUID of the item that has been added or changed (e.g. `"item_id": UUID`)
-- To log the fields that are modified when an item is updated in the datastore (e.g. `"fields": "password,notes"`  (because the value has to be a string we will have to concat the fields that were updated somehow)
+- To log the fields that are modified when an item is updated in the datastore (e.g. `"fields": "username,passsword,address"` (because the value has to be a string we will have to concat the fields that were updated somehow)
 
 Once an event is registered, we can record it with:
 
-`Services.telemetry.recordEvent(category, method, object, null, extra)`
+`Services.telemetry.recordEvent(category, method, object, value, extra)`
 
-When recording, we can use `null` for `value`.
+Note: The semantics of `value` is contingent on the event being recorded, see list below.
 
 See the Events section for specific examples of event registration and recording.
 
@@ -124,39 +109,44 @@ Services.telemetry.scalarSet(
 	"category.scalar_name", value
 );
 ```
-e.g. `lockboxV1.datastoreCount` for the scalar name.
+e.g. `lockbox-addon.loginCount` for the scalar name.
 
 We can also use `scalarAdd` to increment a scalar value by some amount.
 
 ## Scalar Metrics
 
-These are the metrics we currently collect regarding the state of user datastores.
+These are the metrics we currently collect regarding the state of the user's login storage.
 
-- `datastoreCount` (integer). Current count of the number of items in the user's datastore. Note that this scalar is only updated when the user renders their full item list, either in the management view or in the doorhanger. So when testing whether this scalar is accurately updated, please re-render the item list.
+- `loginCount` (SCALAR_TYPE_COUNT). Current count of the number of items in the user's login storage. If possible, this scalar should be set upon opening either the doorhanger or full extension interface.
 
-## List of Events Currently Recorded
+- `loginsAccessedAllTime` (SCALAR_TYPE_COUNT). Running total of logins accessed (copied, revealed) through the extension interface or doorhanger. Should never be reset.
 
-All events are currently implemented under the **category: lockboxV2**. The `extra` field contains `itemid` for events pertaining to a particular Lockbox item. They are listed and grouped together below based on the contents of the event's `method` field.
+- `loginsAccessed` (SCALAR_TYPE_COUNT). Total of logins accessed (copied, revealed) since last ping through the extension interface or doorhanger. TODO: in native code scalars are automatically reset when a new ping is cut. Will that happen for us?
 
-1. `startup` fires when the webextension is loaded. **objects**: webextension. Note that this event fires whenever the browser is started, so is not indicative of direct user interaction with Lockbox.
+Note that if the preceding two scalars are going to cause engineering headaches its possible to obtain equivalent values from the event telemetry (its just more work).
 
-2. `iconClick` fires when someone clicks the toolbar icon. **objects**: toolbar
+## List of Planned Metrics Events
 
-3. `render` events fire when the item manager or doorhanger (when implemented) are rendered. **objects**: manage, doorhanger
+All events are currently implemented under the **category: lockbox-addon**. The `extra` field contains `itemid` for events pertaining to a particular Lockbox item. They are listed and grouped together below based on the contents of the event's `method` field.
 
-4. `itemAdding`, `itemUpdating`, `itemDeleting` fire when a user clicks to submit a new item or edit or delete an existing item. **objects**: addItemForm, updatingItemForm
+1. `startup` fires when the webextension is loaded. **objects**: webextension. Note that this event fires whenever the browser is started, so is not indicative of direct user interaction with Lockbox. **value** is null.
 
-5.  `itemAdded`, `itemUpdated`, `itemDeleted` fire after a successful add/update/delete action. **objects**: addItemForm, updatingItemForm
+2. `click` fires when someone clicks on one of the UI elements listed **objects**: `toolbar`, `get_mobile`, `faq`, `account_settings`, `give_feedback`, `settings_menu` (or whatever the menu is that contains links to account settings, faq, etc). **value** is null.
 
-6. `added`, `updated`, `deleted` fire when an item is added/updated/deleted in the backend datastore. Has itemid in the extra field. **objects**: datastore
+3. `show` events fire when various UI elements are rendered shown to the user. **objects**: `item_list_manager`, `item_list_doorhanger`, `item_detail_doorhanger` `item_detail_manager`, `new_item`, `item_edit`, `delete_confirm`, `connect_another_device`, `reconnect_sync` **value** should be a boolean for `item_list_*` events indicating whether any logins are in the login list (e.g. `False` if the list is empty).
 
-7. `itemSelected` fires when a user clicks an item in the itemlist. **objects** itemList  
+4. `item_add`, `item_update`, `item_delete` fire after a successful adding, editing or deleting of a credential. **objects**: manager, doorhanger (contingent on where the user initiated the action). item GUID should be in the extra field. **value** is null
 
-8. `usernameCopied` and `passwordCopied` fire when a user copies their username or password from an item. **objects**: itemDetails
+5. `item_selected` fires when a user clicks an item in the itemlist. **objects** manager, doorhanger  **value** is null
 
-9. `feedbackClick` fires when the user clicks the "Send Feedback" button. **objects**: manage
+6. `copy_password` and `copy_username` fire when a user copies their username or password from an item. **objects**: `item_detail_manager`, `item_detail_doorhanger` **value** is null
 
-10. `faqClick` fires when the user clicks the "FAQ" button. **objects**: manage
+7. `reveal_password` fires when a user reveals a password from within the item detail view. **objects**: `item_detail_manager`, `item_detail_doorhanger` **value** is null
+
+8. `open_website` fires when a user clicks to open a credential's associated web address. **objects**: `item_detail_manager`, `item_detail_doorhanger` **value** is null
+
+
+
 
 ---
 


### PR DESCRIPTION
Connected to https://github.com/mozilla-lockbox/lockbox-addon/issues/29 and https://github.com/mozilla-lockbox/lockbox-addon/issues/5

## Testing and Review Notes

These are the metrics I'm proposing for the first iteration of the addon. 

I based the event schemas on the [invision designs](https://mozilla.invisionapp.com/share/ENOL84959AK#/screens/339614512). If there's other nomenclature that is better compatible with what's in the code, I'm fine with that.

Also, note that a couple of scalars that I proposed might pose technical hurdles. Happy to talk about that. 

I also left out the monitor bits for now. 

