### PR TITLE
Open FxA/Sync Prefs

### DIFF
--- a/src/experiments/sync/api.js
+++ b/src/experiments/sync/api.js
@@ -58,6 +58,10 @@ this.sync = class extends ExtensionAPI {
             const profileInfo = await getProfileInfo();
             return profileInfo;
           },
+          async openPreferences(entrypoint) {
+            const win = Services.wm.getMostRecentWindow("navigator:browser");
+            win.openPreferences("paneSync", { urlParams: { entrypoint } });
+          },
           onUserProfileChanged: new EventManager(context, "sync.onUserProfileChanged", async (fire) => {
             let oldValue = await getProfileInfo();
             const callback = (value) => {

--- a/src/experiments/sync/api.js
+++ b/src/experiments/sync/api.js
@@ -16,14 +16,14 @@ ChromeUtils.defineModuleGetter(this, "UIState",
 ChromeUtils.defineModuleGetter(this, "ObjectUtils",
                                "resource://gre/modules/ObjectUtils.jsm");
 
+// STATUS_LOGIN_FAILED means the password was changed on another device, and the
+// user needs to log in again.
+// STATUS_NOT_VERIFIED means the user has logged in with an unverified email.
+// In both cases, the user needs to take action elsewhere in Firefox.
+const FxAErrors = [UIState.STATUS_LOGIN_FAILED, UIState.STATUS_NOT_VERIFIED];
+
 const getProfileInfo = async () => {
   const uiState = UIState.get();
-  // STATUS_LOGIN_FAILED means the password was changed on another device, and the
-  // user needs to log in again.
-  // STATUS_NOT_VERIFIED means the user has logged in with an unverified email.
-  // In both cases, the user needs to take action elsewhere in Firefox.
-  const errors = [UIState.STATUS_LOGIN_FAILED, UIState.STATUS_NOT_VERIFIED];
-
   let profileInfo;
 
   // STATUS_NOT_CONFIGURED means the user is not logged in.
@@ -31,7 +31,7 @@ const getProfileInfo = async () => {
     profileInfo = null;
   } else { // UIState.STATUS_SIGNED_IN, the user is logged in and verified.
     const fxa = await UIState._internal.fxAccounts.getSignedInUser();
-    const isErrorStatus = errors.includes(uiState.status);
+    const isErrorStatus = FxAErrors.includes(uiState.status);
 
     profileInfo = {
       id: fxa && fxa.uid,
@@ -43,6 +43,16 @@ const getProfileInfo = async () => {
   }
 
   return profileInfo;
+};
+
+const openPrefs = async (origin, entrypoint) => {
+  const win = Services.wm.getMostRecentWindow("navigator:browser");
+
+  win.openPreferences("paneSync", { origin, urlParams: { entrypoint } });
+};
+const openSignIn = async (entrypoint) => {
+  // TODO: be smarter like browser?
+  return openPrefs("fxaError", entrypoint);
 };
 
 this.sync = class extends ExtensionAPI {
@@ -58,9 +68,20 @@ this.sync = class extends ExtensionAPI {
             const profileInfo = await getProfileInfo();
             return profileInfo;
           },
+
           async openPreferences(entrypoint) {
-            const win = Services.wm.getMostRecentWindow("navigator:browser");
-            win.openPreferences("paneSync", { urlParams: { entrypoint } });
+            const uiState = UIState.get();
+
+            switch (uiState.status) {
+              case UIState.STATUS_SIGNED_IN:
+                return openPrefs("fxaSignedin", entrypoint);
+              case UIState.STATUS_NOT_VERIFIED:
+                return openPrefs("fxaError", entrypoint);
+              case UIState.STATUS_LOGIN_FAILED:
+                return openSignIn(entrypoint);
+            }
+
+            return openPrefs("fxa", entrypoint);
           },
           onUserProfileChanged: new EventManager(context, "sync.onUserProfileChanged", async (fire) => {
             let oldValue = await getProfileInfo();

--- a/src/experiments/sync/schema.json
+++ b/src/experiments/sync/schema.json
@@ -88,6 +88,17 @@
         "description": "Returns a Promise that resolves to the UserProfileInfo, if the user is logged in, or null otherwise.",
         "async": true,
         "parameters": []
+      },
+      {
+        "name": "openPreferences",
+        "type": "function",
+        "description": "Opens the Profile/Sync management page.",
+        "async": true,
+        "parameters": [{
+          "name": "entrypoint",
+          "type": "string",
+          "description": "The name of the entrypoint into the management page; e.g., the caller"
+        }]
       }
     ]
   }

--- a/src/list/common.js
+++ b/src/list/common.js
@@ -53,3 +53,7 @@ export const openWebsite = (url, closeWindow = true) => {
     window.close();
   }
 };
+
+export const openSyncPrefs = () => {
+  browser.experiments.sync.openPreferences("lockbox-addon");
+};

--- a/src/list/manage/containers/app-header.js
+++ b/src/list/manage/containers/app-header.js
@@ -7,7 +7,7 @@ import { Localized } from "fluent-react";
 import PropTypes from "prop-types";
 import React from "react";
 import { connect } from "react-redux";
-import { openWebsite } from "../../common";
+import { openWebsite, openSyncPrefs } from "../../common";
 import { classNames } from "../../../common";
 import {
   selectTabLogins,
@@ -235,11 +235,7 @@ export default connect(
     onClickMenuConnect: () => {
       // TODO: Issue TBD
     },
-    onClickMenuAccount: () => {
-      // TODO: Issue #92 / Issue #61
-    },
-    onClickMenuSignIn: () => {
-      // TODO: Issue #92 / Issue #61
-    },
+    onClickMenuAccount: () => openSyncPrefs(),
+    onClickMenuSignIn: () => openSyncPrefs(),
   })
 )(AppHeader);

--- a/test/integration/sync-api-test.js
+++ b/test/integration/sync-api-test.js
@@ -54,6 +54,10 @@ describe("sync API", () => {
     return output;
   };
 
+  const openSyncPrefs = async () => {
+    await clickButton("open-sync-prefs");
+  };
+
   // Force an update of the UIState. This method exists on the UIState API to
   // aid with rapid state transitions during testing.
   const refreshUIState = async () => {
@@ -253,6 +257,32 @@ describe("sync API", () => {
       await refreshUIState();
       result = await getPasswordsPref();
       expect(JSON.parse(result)).to.be.true;
+    });
+  });
+
+  describe("browser.expermients.sync.openPreferences", () => {
+    it("should open FxA/sync preference page when not configured", async () => {
+      await setNotConfigured();
+      await loadTestPage();
+      await openSyncPrefs();
+
+      // TODO: verify page opened ...
+    });
+
+    it("should open FxA/sync preference page when signed-in", async () => {
+      await setLoggedIn();
+      await loadTestPage();
+      await openSyncPrefs();
+
+      // TODO: verify page opened ...
+    });
+
+    it("should open FxA/sync prefeerence page when there's a problem", async () => {
+      await setLoginFailed();
+      await loadTestPage();
+      await openSyncPrefs();
+
+      // TODO: verify page opened ...
     });
   });
 

--- a/test/integration/test-pages/sync-api.html
+++ b/test/integration/test-pages/sync-api.html
@@ -9,6 +9,10 @@
   <button id="get-profile-info">Get Profile Info</button>
   <pre id="get-profile-info-results"></pre>
 
+<p>Click the Open Preferences button to open the preferences page to the FxA/Sync pane.
+  <button id="open-sync-prefs">Open Preferences</button>
+  <pre id="open-sync-prefs-results"></pre>
+
 <p>Click the Register Listener button to register an onUserProfileChanged listener.
    Any events will be appended to a list in the results field.
   <button id="register-listener">Register Listener</button>

--- a/test/integration/test-pages/sync-api.js
+++ b/test/integration/test-pages/sync-api.js
@@ -18,6 +18,12 @@ document.querySelector("#check-passwords-pref").addEventListener("click", () => 
     then(log, log);
 });
 
+document.querySelector("#open-sync-prefs").addEventListener("click", () => {
+  const log = getLogger("open-sync-prefs");
+  browser.experiments.sync.openPreferences("lockbox-addon-tests").
+    then(log, log);
+});
+
 document.querySelector("#register-listener").addEventListener("click", () => {
   const events = [];
   const log = getLogger("register-listener");

--- a/test/unit/list/common-test.js
+++ b/test/unit/list/common-test.js
@@ -2,11 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { expect } from "chai";
+import chai, { expect } from "chai";
 import sinon from "sinon";
+import sinonChai from "sinon-chai";
 import "test/unit/mocks/browser";
 
 import * as common from "src/list/common";
+
+chai.use(sinonChai);
 
 describe("list > common", () => {
   describe("openSyncPrefs", () => {
@@ -21,7 +24,7 @@ describe("list > common", () => {
 
     it("call WebExt API", async () => {
       common.openSyncPrefs();
-      spyOpenPrefs.calledWith("lockbox-addon");
+      expect(spyOpenPrefs).to.have.been.calledWith("lockbox-addon");
     });
   });
 });

--- a/test/unit/list/common-test.js
+++ b/test/unit/list/common-test.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { expect } from "chai";
+import sinon from "sinon";
+import "test/unit/mocks/browser";
+
+import * as common from "src/list/common";
+
+describe("list > common", () => {
+  describe("openSyncPrefs", () => {
+    let spyOpenPrefs;
+
+    beforeEach(() => {
+      spyOpenPrefs = sinon.spy(browser.experiments.sync, "openPreferences");
+    });
+    afterEach(() => {
+      spyOpenPrefs.restore();
+    });
+
+    it("call WebExt API", async () => {
+      common.openSyncPrefs();
+      spyOpenPrefs.calledWith("lockbox-addon");
+    });
+  });
+});

--- a/test/unit/mocks/browser.js
+++ b/test/unit/mocks/browser.js
@@ -218,6 +218,7 @@ window.browser = {
     },
     sync: {
       async getUserProfileInfo() { },
+      async openPreferences() { },
       onUserProfileChanged: new MockListener(),
     },
   },


### PR DESCRIPTION
Fixes #92 

Adds a WebExt API for opening FxA/Sync Preferences within Firefox, so that the user menu items for "Account" and "Sign in to Sync" do something.

The work for #61 depends on at least the webext API, and probably also the helper added herein.

## Testing and Review Notes

* Integration tests verify the webext API opens "about:preferences...#sync".
* Clicking "Account" or "Sign in to Sync" from the user menu on the management page should open the FxA/Sync preferences.

The integration tests are kind of "brute force" walking the open windows/tabs looking for a matching URL.  There might be a better way to do this, but it's not obvious.

## Screenshots or Videos

* "Sign in to Sync" menu item (no account yet):
![desktop-92 sign-in-menu](https://user-images.githubusercontent.com/757401/54222201-8e172c80-44ba-11e9-975c-8da6b52bb07e.gif)

* "Account" menu item (signed into Sync):
![desktop-92 account-menu](https://user-images.githubusercontent.com/757401/54222112-5dcf8e00-44ba-11e9-9a48-efc4175a687d.gif)

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add integration tests
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
