### PR TITLE
Make CI Fail on Enforced Lint Errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,6 +182,7 @@ workflows:
           requires:
             - build
             - test
+            - lint
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,27 @@ jobs:
           root: .
           paths:
             - ./*
+  lint:
+    docker:
+      - image: circleci/node
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: update-npm
+          command: 'sudo npm install -g npm@6.7'
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run:
+          name: install-npm
+          command: npm ci
+      - save_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
+      - run:
+          name: lint
+          command: npm run lint
   test:
     docker:
       - image: circleci/node
@@ -61,9 +82,6 @@ jobs:
           command: npm run integration
           environment:
             LOCKBOX_FIREFOX_HEADLESS: "1"
-      - run:
-          name: linting
-          command: npm run lint
   package-addon-production:
     docker:
       - image: circleci/node
@@ -143,6 +161,9 @@ workflows:
     jobs:
       - build
       - test:
+          requires:
+            - build
+      - lint:
           requires:
             - build
       - build-documentation:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,9 @@ jobs:
           command: npm run integration
           environment:
             LOCKBOX_FIREFOX_HEADLESS: "1"
+      - run:
+          name: linting
+          command: npm run lint
   package-addon-production:
     docker:
       - image: circleci/node

--- a/test/unit/list/manage/reducers-test.js
+++ b/test/unit/list/manage/reducers-test.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { expect } from "chai";
+import chai, { expect } from "chai";
 
 import * as actions from "src/list/actions";
 import {

--- a/test/unit/list/manage/reducers-test.js
+++ b/test/unit/list/manage/reducers-test.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import chai, { expect } from "chai";
+import { expect } from "chai";
 
 import * as actions from "src/list/actions";
 import {


### PR DESCRIPTION
Found while working on an earlier patch; enforced linting is not part of the build, which can mean some classes of errors won't trigger a failure.

## Testing and Review Notes

Changing the code so that it would still function, but JavaScript or CSS linting would produce errors.


## To Do

- [x] make sure CI builds are passing (e.g.: fix lint and other errors)