### PR TITLE
Fix Locale identifiers to match text

### DIFF
--- a/src/locales/en-US/list.ftl
+++ b/src/locales/en-US/list.ftl
@@ -116,8 +116,8 @@ item-details-save-existing = Save Changes
 item-details-cancel = Cancel
 
 item-details-created = Created: {$date}
-item-details-created = Last Modified: {$date}
-item-details-created = Last Used: {$date}
+item-details-modified = Last Modified: {$date}
+item-details-last-used = Last Used: {$date}
 
 list-count = {$count} entries
 


### PR DESCRIPTION
This fixes a couple of typos in the fluent localization files, which mistakenly associated each of the metadata labels to the same identifier.

Fixes #103

## Testing and Review Notes

It might make sense to update the integration tests to check for the correct label/prefix, though it is obvious from a manual inspection, and is very unlikely this data will change.


## Screenshots or Videos

### BEFORE
<img width="307" alt="image" src="https://user-images.githubusercontent.com/757401/54392825-2c97bf00-466e-11e9-8123-8d42c6e3af46.png">

### AFTER
<img width="229" alt="image" src="https://user-images.githubusercontent.com/757401/54449933-d6318b80-4714-11e9-83e7-6ed099afe223.png">

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)