### PR TITLE
WIP: Register about:logins to show the list view (#13)

### DIFF
--- a/src/background/environment.js
+++ b/src/background/environment.js
@@ -11,4 +11,6 @@ export async function initializeEnvironment() {
     await browser.experiments.logins
       .setLoginSavingEnabled(origin, false);
   }
+
+  browser.experiments.aboutLogins.register();
 }

--- a/src/experiments/aboutLogins/about-logins.jsm
+++ b/src/experiments/aboutLogins/about-logins.jsm
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+var EXPORTED_SYMBOLS = ["AboutLogins"];
+
+const {Services} = ChromeUtils.import("resource://gre/modules/Services.jsm");
+
+const addonID = "lockbox@mozilla.com";
+const addonPageRelativeURL = "/list/manage.html";
+
+function AboutLogins() {
+  this.chromeURL = WebExtensionPolicy.getByID(addonID).getURL(addonPageRelativeURL);
+}
+AboutLogins.prototype = {
+  QueryInterface: ChromeUtils.generateQI([Ci.nsIAboutModule]),
+  getURIFlags() {
+    return Ci.nsIAboutModule.ALLOW_SCRIPT |
+           Ci.nsIAboutModule.URI_MUST_LOAD_IN_EXTENSION_PROCESS;
+  },
+
+  newChannel(aURI, aLoadInfo) {
+    const uri = Services.io.newURI(this.chromeURL);
+    const channel = Services.io.newChannelFromURIWithLoadInfo(uri, aLoadInfo);
+    channel.originalURI = aURI;
+
+    channel.owner = Services.scriptSecurityManager.createCodebasePrincipal(uri, aLoadInfo.originAttributes);
+    return channel;
+  },
+};

--- a/src/experiments/aboutLogins/about-page-process-script.js
+++ b/src/experiments/aboutLogins/about-page-process-script.js
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const Cm = Components.manager.QueryInterface(Ci.nsIComponentRegistrar);
+
+const classID = Components.ID("{8ddaffa4-0598-47c8-a966-ee9cbb76868f}");
+
+if (!Cm.isCIDRegistered(classID)) {
+  const {XPCOMUtils} = ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm", {});
+
+  const factory = XPCOMUtils.generateSingletonFactory(function() {
+    const {AboutLogins} = ChromeUtils.import("resource://lockbox/experiments/aboutLogins/about-logins.jsm", {});
+    return new AboutLogins();
+  });
+
+  Cm.registerFactory(classID, "about:logins",
+                     "@mozilla.org/network/protocol/about;1?what=logins",
+                     factory);
+}

--- a/src/experiments/aboutLogins/api.js
+++ b/src/experiments/aboutLogins/api.js
@@ -1,0 +1,35 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/* globals AppConstants, browser, Components, dispatcher,
+   ExtensionCommon, ExtensionAPI, Services, XPCOMUtils */
+
+"use strict";
+
+ChromeUtils.defineModuleGetter(this, "Services",
+                               "resource://gre/modules/Services.jsm");
+XPCOMUtils.defineLazyServiceGetter(this, "resProto",
+                                   "@mozilla.org/network/protocol;1?name=resource",
+                                   "nsISubstitutingProtocolHandler");
+
+const resourceHost = "lockbox";
+const processScriptPath = "experiments/aboutLogins/about-page-process-script.js";
+
+this.aboutLogins = class extends ExtensionAPI {
+  getAPI(context) {
+    return {
+      experiments: {
+        aboutLogins: {
+          register() {
+            resProto.setSubstitution(resourceHost, context.extension.baseURI);
+            const processScriptURL = context.extension.baseURI.resolve(processScriptPath);
+            Services.ppmm.loadProcessScript(processScriptURL, true);
+          },
+        },
+      },
+    };
+  }
+};

--- a/src/experiments/aboutLogins/schema.json
+++ b/src/experiments/aboutLogins/schema.json
@@ -1,0 +1,15 @@
+[
+  {
+    "namespace": "experiments.aboutLogins",
+    "description": "Firefox Lockbox internal API for registering about:logins",
+    "functions": [
+      {
+        "name": "register",
+        "type": "function",
+        "description": "Register about:logins to point to the management page.",
+        "async": false,
+        "parameters": []
+      }
+    ]
+  }
+]

--- a/src/manifest.json.tpl
+++ b/src/manifest.json.tpl
@@ -9,7 +9,7 @@
   },
 
 
-  "content_security_policy": "script-src 'self' {{testing_csp_scripts}} ; object-src 'self' {{testing_csp_objects}}",
+  "content_security_policy": "script-src 'self' 'sha256-HbSjs39Y0thRGfO3RHrNzLPKyC/tq6FdIuP3jEBAcJQ=' {{testing_csp_scripts}} ; object-src 'self' {{testing_csp_objects}}",
 
   "applications": {
     "gecko": {
@@ -39,6 +39,14 @@
   },
 
   "experiment_apis": {
+    "aboutLogins": {
+      "schema": "experiments/aboutLogins/schema.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "script": "experiments/aboutLogins/api.js",
+        "paths": [["experiments", "aboutLogins"]]
+      }
+    },
     "logins": {
       "schema": "experiments/logins/schema.json",
       "parent": {

--- a/src/template.ejs
+++ b/src/template.ejs
@@ -4,7 +4,11 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <html>
   <head>
+    <base>
     <meta charset="utf-8"/>
+    <!-- If you change this script tag you must update the hash in the extension's
+         `content_security_policy`: 'sha256-HbSjs39Y0thRGfO3RHrNzLPKyC/tq6FdIuP3jEBAcJQ=' -->
+    <script>document.head.firstElementChild.href = browser.runtime.getURL("");</script>
     <% for (let css of htmlWebpackPlugin.files.css) { %>
     <link href="<%- css %>" rel="stylesheet">
     <% } for (let js of htmlWebpackPlugin.files.js) { %>


### PR DESCRIPTION
Fixes #13

## Testing and Review Notes

Even though I think we should consider something like `https://passwords.firefox.com` instead so that it's cross-browser… here is a patch to register about:logins. This doesn't do proper cleanup/teardown to unregister the resource: and about: URIs but someone else can feel free to add that. I also don't have any automated tests for it.

Acceptance criteria
- [ ] Management tab should be navigable from somewhere else (e.g., clicking a link) and back
- - This may be possible by [adding two flags](https://searchfox.org/mozilla-central/rev/a7315d78417179b151fef6108f2bce14786ba64d/netwerk/protocol/about/nsIAboutModule.idl#34,72) to the about: URI but then you lose all permissions. If you just need to be able to link to this from within privileged Firefox code then we're all set.
- [ ] If linked, Management interface URL should open in new tab or window
See above but we also can't really force URLs from arbitrary content to open in a certain way.
- [x] Should show up in recently closed tabs
- [x] Should be able to be bookmarked

## Screenshots or Videos

![image](https://user-images.githubusercontent.com/601139/55201600-f3d50b00-5180-11e9-829c-6c0b1293ab24.png)

## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding integration tests
- [x] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [x] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-addon/developer/test-plan-accessibility/) of any added UI