### PR TITLE
Set an item on management page load to avoid blank home page

### DIFF
--- a/docs/developer/releases.md
+++ b/docs/developer/releases.md
@@ -14,7 +14,7 @@ Before a release can be made, the following must be done:
 **NOTE:** these instructions assume:
 
 * All of the [checklist items](#checklist) are complete
-* You are an administrator of the project `lockbox-extension`
+* You are an administrator of the project `lockbox-addon`
 * Your local git working copy has a remote named `upstream` pointing to `git@github.com:mozilla-lockbox/lockbox-addon.git`
 
 To generate the next release binary:
@@ -33,43 +33,13 @@ To generate the next release binary:
     * consult with Product Management on wording if needed
 
 3. Commit and ultimately merge to `master` branch
-4. Create a pull request on GitHub [comparing changes from the `master` branch against/to `production`][production-compare]
+4. Create a tag on the release tab in GitHub
 
-    * Open the pull request so we can show the changes, CI status, and approvals
-      * Request an approval from the P.I. and Product representatives
-    * Once the release has been reviewed, tested, and approved to go live, merge and close the pull request
-    * Test Pilot's Jenkins will then build, sign, and deploy the extension (see ["Extension Signing"](#extension-signing))
+    * Name the release the same as the addon version
+    * Add same release notes added in step 2 above
+    * CircleCI will build and generate a [GitHub Release][releases]
+      * You will be able to view progress in the [circleci project dashboard](https://circleci.com/gh/mozilla-lockbox/lockbox-addon)
 
-5. Tag the latest commit on `master` branch with an annotated version and push the tag:
+5. Send an announcement to the team (e.g., via Slack team channel)
 
-    * `git tag -a -m "Release 0.1.0" 0.1.0`
-    * `git push upstream 0.1.0`
-    * Travis-CI will build and generate a [GitHub Release][releases]
-
-6. Edit the resulting GitHub Release
-
-    * Set the [GitHub Release][releases] title to match the version
-    * Set the GitHub Release notes to match the `docs/release-notes.md`
-    * Download the signed add-on: `wget -O signed-addon.xpi https://testpilot.firefox.com/files/lockbox@mozilla.com/latest`
-    * Attach to the GitHub Release the downloaded signed add-on
-
-7. Send an announcement to the team (e.g., via Slack team channel)
-
-## Extension Signing
-
-Learn about the Test Pilot extension deployment and hosting process here:  
-https://github.com/mozilla/testpilot/blob/master/docs/development/hosting.md
-
-This repository is in the **"testpilot-mozillaextension"** Jenkins pipeline.
-The CloudOps team manages access to, and can help report on, the status of the
-builds.
-
-The resulting files deployed are:
-
-- Updates file for automatic browser extension updates: [https://testpilot.firefox.com/files/lockbox@mozilla.com/updates.json](https://testpilot.firefox.com/files/lockbox@mozilla.com/updates.json)
-- Latest version of the signed extension XPI: [https://testpilot.firefox.com/files/lockbox@mozilla.com/latest](https://testpilot.firefox.com/files/lockbox@mozilla.com/latest)
-
-**IMPORTANT:** Test Pilot reports the status of build, signing, and deployment of its artifacts on the IRC channel **#testpilot-bots**.  Be sure to join the channel prior to pushing the `production` branch to GitHub in order to receive the status updates.
-
-[production-compare]: https://github.com/mozilla-lockbox/lockbox-addon/compare/production...master
 [releases]: https://github.com/mozilla-lockbox/lockbox-addon/releases

--- a/src/list/manage/index.js
+++ b/src/list/manage/index.js
@@ -44,26 +44,22 @@ let store;
 
   // if no filter check ensure that we have a default item selected
   const state = store.getState();
-  const all = state.cache.items;
-  let filteredItems = all;
+  const allItems = state.cache.items;
+  let selectedItems = allItems;
 
   if (state.list.filter && !state.list.filter.userEntered) {
-    console.log(`filter by ${state.list.filter.query}`);
     const filter = parseFilterString(state.list.filter.query);
-    filteredItems = all
+    selectedItems = allItems
       .filter((i) => filterItem(filter, i));
-    if (!filteredItems.length) {
-      filteredItems = all.slice();
+    if (!selectedItems.length) {
+      selectedItems = allItems.slice();
     }
-  } else {
-    console.log("no filter applied!");
   }
-  console.log(`sort by ${ state.cache.sort }`);
-  const sortFn = getSort(state.cache.sort);
-  filteredItems = filteredItems.sort(sortFn);
 
-  if (filterItems.length) {
-    store.dispatch(requestSelectItem(filteredItems[0].id));
+  if (selectedItems.length) {
+    const sortFn = getSort(state.cache.sort);
+    selectedItems = selectedItems.sort(sortFn);
+    store.dispatch(requestSelectItem(selectedItems[0].id));
   }
 
   ReactDOM.render(

--- a/src/list/manage/index.js
+++ b/src/list/manage/index.js
@@ -41,11 +41,15 @@ let store;
   store.dispatch(getProfile());
   applyQueryFilter();
 
-  // select a default item so the home view is not empty
-  const cache = store.getState().cache;
-  if (cache.items.length) {
-    const sortedList = cache.items.sort(getSort(cache.sort));
-    store.dispatch(requestSelectItem(sortedList[0].id));
+  // if no filter check ensure that we have a default item selected
+  const params = new URLSearchParams(window.location.search);
+  const filter = params.get("filter");
+  if (!filter) {
+    const cache = store.getState().cache;
+    if (cache.items.length) {
+      const sortedList = cache.items.sort(getSort(cache.sort));
+      store.dispatch(requestSelectItem(sortedList[0].id));
+    }
   }
 
   ReactDOM.render(

--- a/src/list/manage/index.js
+++ b/src/list/manage/index.js
@@ -18,6 +18,7 @@ import { saveSort, loadSort } from "./sort-middleware";
 import openLink from "../open-link-middleware";
 
 import { getSort } from "../sort";
+import { filterItem, parseFilterString } from "../filter";
 
 const applyQueryFilter = () => {
   // parse query params ...
@@ -42,14 +43,27 @@ let store;
   applyQueryFilter();
 
   // if no filter check ensure that we have a default item selected
-  const params = new URLSearchParams(window.location.search);
-  const filter = params.get("filter");
-  if (!filter) {
-    const cache = store.getState().cache;
-    if (cache.items.length) {
-      const sortedList = cache.items.sort(getSort(cache.sort));
-      store.dispatch(requestSelectItem(sortedList[0].id));
+  const state = store.getState();
+  const all = state.cache.items;
+  let filteredItems = all;
+
+  if (state.list.filter && !state.list.filter.userEntered) {
+    console.log(`filter by ${state.list.filter.query}`);
+    const filter = parseFilterString(state.list.filter.query);
+    filteredItems = all
+      .filter((i) => filterItem(filter, i));
+    if (!filteredItems.length) {
+      filteredItems = all.slice();
     }
+  } else {
+    console.log("no filter applied!");
+  }
+  console.log(`sort by ${ state.cache.sort }`);
+  const sortFn = getSort(state.cache.sort);
+  filteredItems = filteredItems.sort(sortFn);
+
+  if (filterItems.length) {
+    store.dispatch(requestSelectItem(filteredItems[0].id));
   }
 
   ReactDOM.render(

--- a/src/list/manage/index.js
+++ b/src/list/manage/index.js
@@ -10,12 +10,14 @@ import thunk from "redux-thunk";
 
 import AppLocalizationProvider from "../../l10n";
 import App from "./components/app";
-import { listItems, getProfile, filterItems } from "../actions";
+import { listItems, getProfile, filterItems, requestSelectItem } from "../actions";
 import reducer from "./reducers";
 import initializeMessagePorts from "../message-ports";
 import telemetryLogger from "./telemetry";
 import { saveSort, loadSort } from "./sort-middleware";
 import openLink from "../open-link-middleware";
+
+import { getSort } from "../sort";
 
 const applyQueryFilter = () => {
   // parse query params ...
@@ -34,10 +36,17 @@ let store;
   store = createStore(reducer, preloadedState, applyMiddleware(
     thunk, telemetryLogger, saveSort, openLink,
   ));
-  store.dispatch(listItems());
+  await store.dispatch(listItems());
   initializeMessagePorts(store);
   store.dispatch(getProfile());
   applyQueryFilter();
+
+  // select a default item so the home view is not empty
+  const cache = store.getState().cache;
+  if (cache.items.length) {
+    const sortedList = cache.items.sort(getSort(cache.sort));
+    store.dispatch(requestSelectItem(sortedList[0].id));
+  }
 
   ReactDOM.render(
     <Provider store={store}>

--- a/test/unit/list/manage/components/app-test.js
+++ b/test/unit/list/manage/components/app-test.js
@@ -80,4 +80,21 @@ describe("list > manage > components > <App/>", () => {
     expect(wrapper.find("input")).to.be.focused();
     expect(wrapper.find("input")).to.have.selection();
   });
+
+  it("Default view item", () => {
+    const store = mockStore({
+      ...filledState,
+      list: {
+        ...filledState.list,
+      },
+    });
+
+    const wrapper = mountWithL10nIntoDOM(
+      <Provider store={store}>
+        <App/>
+      </Provider>
+    );
+
+    expect(wrapper.find("#itemDetails")).to.have.length(1);
+  });
 });


### PR DESCRIPTION
- fixes #148

If there we have an item list, we select the first in the list based on the cached sort. This allows us to not have an empty view on load.

If there is a filter query in the url we still show the homepage.

![default-view-woohoo](https://user-images.githubusercontent.com/1844554/56687851-2fda8d80-66a5-11e9-9a02-b2c42f30238c.jpg)


## To Do
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
- [x] request the "UX" team perform a design review (if/when applicable)
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
- [x] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-addon/developer/test-plan-accessibility/) of any added UI
- [x] make sure any new UI has telemetry events wired up and documented in docs/metrics.md, and verify that the events are recording properly (visit `about:telemetry#events-tab`, then choose 'dynamic' from the dropdown menu at top right, to view events fired by the addon
