### PR TITLE
Implement "Connect another device" modal

### DIFF
--- a/src/experiments/sync/api.js
+++ b/src/experiments/sync/api.js
@@ -64,6 +64,9 @@ this.sync = class extends ExtensionAPI {
     return {
       experiments: {
         sync: {
+          async getCurrentState(syncType) {
+            return Services.prefs.getBoolPref("services.sync.engine." + syncType, false);
+          },
           async getUserProfileInfo() {
             const profileInfo = await getProfileInfo();
             return profileInfo;

--- a/src/experiments/sync/api.js
+++ b/src/experiments/sync/api.js
@@ -24,6 +24,7 @@ const FxAErrors = [UIState.STATUS_LOGIN_FAILED, UIState.STATUS_NOT_VERIFIED];
 
 const getProfileInfo = async () => {
   const uiState = UIState.get();
+  const syncEnabled = Services.prefs.getBoolPref("services.sync.engine.passwords", false);
   let profileInfo;
 
   // STATUS_NOT_CONFIGURED means the user is not logged in.
@@ -39,6 +40,7 @@ const getProfileInfo = async () => {
       displayName: uiState.displayName || null,
       avatar: uiState.avatarURL || null,
       status: isErrorStatus ? "error" : "ok",
+      syncEnabled,
     };
   }
 
@@ -58,17 +60,14 @@ const openSignIn = async (entrypoint) => {
 this.sync = class extends ExtensionAPI {
   getAPI(context) {
     const EventManager = ExtensionCommon.EventManager;
+
     return {
       experiments: {
         sync: {
-          async getCurrentState(syncType) {
-            return Services.prefs.getBoolPref("services.sync.engine." + syncType, false);
-          },
           async getUserProfileInfo() {
             const profileInfo = await getProfileInfo();
             return profileInfo;
           },
-
           async openPreferences(entrypoint) {
             const uiState = UIState.get();
 
@@ -113,8 +112,10 @@ this.sync = class extends ExtensionAPI {
               },
             };
             Services.obs.addObserver(observer, "sync-ui-state:update");
+            Services.prefs.addObserver("services.sync.engine.passwords", observer);
             return () => {
               Services.obs.removeObserver(observer, "sync-ui-state:update");
+              Services.prefs.removeObserver("services.sync.engine.passwords", observer);
             };
           }).api(),
         },

--- a/src/experiments/sync/schema.json
+++ b/src/experiments/sync/schema.json
@@ -4,17 +4,6 @@
     "description": "Firefox Lockbox internal API for accessing Firefox Accounts/Sync state.",
     "types": [
       {
-        "id": "SyncType",
-        "type": "string",
-        "enum": ["addons", "addresses", "bookmarks", "creditcards", "history", "passwords", "prefs", "tabs"],
-        "description": "Represents different types of data that users can choose to sync across devices. Based on sync engine prefs in Firefox. Note that 'passwords' actually means logins."
-      },
-      {
-        "id": "SyncState",
-        "type": "boolean",
-        "description": "True if the user has enabled sync for the particular SyncType, false otherwise."
-      },
-      {
         "id": "SyncStatus",
         "type": "string",
         "enum": ["error", "ok"],
@@ -47,7 +36,11 @@
           },
           "status": {
             "$ref": "SyncStatus",
-            "description": "Current Sync login status."
+            "description": "Current status of the user's login state in Firefox. See SyncStatus for details."
+          },
+          "syncEnabled": {
+            "type": "boolean",
+            "description": "Status of the user's sync settings for logins. True if the user has enabled logins for sync, false if not. This is a separate issue from whether the user is logged in."
           }
         }
       }
@@ -71,17 +64,6 @@
       }
     ],
     "functions": [
-      {
-        "name": "getCurrentState",
-        "type": "function",
-        "description": "Given a SyncType, returns a Promise that resolves to the SyncState for that type.",
-        "async": true,
-        "parameters": [{
-          "name": "type",
-          "$ref": "SyncType",
-          "description": "SyncType to check."
-        }]
-      },
       {
         "name": "getUserProfileInfo",
         "type": "function",

--- a/src/experiments/sync/schema.json
+++ b/src/experiments/sync/schema.json
@@ -4,6 +4,17 @@
     "description": "Firefox Lockbox internal API for accessing Firefox Accounts/Sync state.",
     "types": [
       {
+        "id": "SyncType",
+        "type": "string",
+        "enum": ["addons", "addresses", "bookmarks", "creditcards", "history", "passwords", "prefs", "tabs"],
+        "description": "Represents different types of data that users can choose to sync across devices. Based on sync engine prefs in Firefox. Note that 'passwords' actually means logins."
+      },
+      {
+        "id": "SyncState",
+        "type": "boolean",
+        "description": "True if the user has enabled sync for the particular SyncType, false otherwise."
+      },
+      {
         "id": "SyncStatus",
         "type": "string",
         "enum": ["error", "ok"],
@@ -64,6 +75,17 @@
       }
     ],
     "functions": [
+      {
+        "name": "getCurrentState",
+        "type": "function",
+        "description": "Given a SyncType, returns a Promise that resolves to the SyncState for that type.",
+        "async": true,
+        "parameters": [{
+          "name": "type",
+          "$ref": "SyncType",
+          "description": "SyncType to check."
+        }]
+      },
       {
         "name": "getUserProfileInfo",
         "type": "function",

--- a/src/icons/icon-desktop.svg
+++ b/src/icons/icon-desktop.svg
@@ -1,0 +1,4 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="context-fill" d="M15.5 12H15V3a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v9H.5a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h15a.5.5 0 0 0 .5-.5v-1a.5.5 0 0 0-.5-.5zM10 13H6v-1h4zm3-2H3V4h10z"></path></svg>

--- a/src/icons/icon-download.svg
+++ b/src/icons/icon-download.svg
@@ -1,0 +1,4 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="context-fill" d="M7.293 12.707a1 1 0 0 0 1.414 0l5-5a1 1 0 0 0-1.414-1.414L9 9.586V1a1 1 0 1 0-2 0v8.586L3.707 6.293a1 1 0 0 0-1.414 1.414zM13 14H3a1 1 0 0 0 0 2h10a1 1 0 0 0 0-2z"></path></svg>

--- a/src/list/actions.js
+++ b/src/list/actions.js
@@ -47,7 +47,6 @@ export const UPDATED_PROFILE = Symbol("UPDATED_PROFILE");
 export const OPEN_FAQ = Symbol("OPEN_FAQ");
 export const OPEN_FEEDBACK = Symbol("OPEN_FEEDBACK");
 export const OPEN_SYNC_PREFS = Symbol("OPEN_SYNC_PREFS");
-export const OPEN_GET_MOBILE = Symbol("OPEN_GET_MOBILE");
 export const SHOW_PROFILE_MENU = Symbol("SHOW_PROFILE_MENU");
 export const OPEN_WEBSITE = Symbol("OPEN_WEBSITE");
 export const OPEN_HOMEPAGE = Symbol("OPEN_HOMEPAGE");
@@ -410,8 +409,8 @@ export function openSyncPrefs(menuItem) {
 }
 
 export function openGetMobile() {
-  return {
-    type: OPEN_GET_MOBILE,
+  return async (dispatch) => {
+    dispatch(showModal("connect-another-device"));
   };
 }
 

--- a/src/list/manage/containers/modals.css
+++ b/src/list/manage/containers/modals.css
@@ -1,0 +1,120 @@
+.connectDevice {
+  width: 660px;
+}
+
+.connectDevice h1 {
+  font-size: 22px;
+  line-height: 33px;
+  font-weight: normal;
+  margin-top: 0;
+}
+
+.connectDevice h2 {
+  font-size: 15px;
+  line-height: 22.5px;
+  font-weight: normal;
+  width: 430px;
+  margin: auto;
+}
+
+.connectDevice h3 {
+  font-size: 17px;
+  line-height: 22.5px;
+  font-weight: normal;
+  display: inline;
+}
+
+.connectDevice li {
+  list-style-type: none;
+  width: 480px;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 30px;
+  text-align: left;
+  position: relative;
+}
+
+.connectDevice a {
+  color: #0060df;
+  cursor: pointer;
+}
+
+.connectDevice p {
+  font-size: 15px;
+  line-height: 22.5px;
+  margin-top: 8px;
+}
+
+.connectDevice li.complete:before,
+.connectDevice li.incomplete:before {
+  content: "";
+  position: absolute;
+  left: -40px;
+  top: 2px;
+  width: 24px;
+  height: 24px;
+  text-align: center;
+  line-height: 24px;
+}
+
+.connectDevice li.incomplete:before {
+  background-color: #ededf0;
+  border: 1px solid #b1b1b3;
+  border-radius: 50%;
+  color: #0c0c0d;
+  font-size: 16px;
+  font-weight: 400;
+}
+
+/* this feels so hacky, but list item decimals don't allow backgrounds */
+.connectDevice li.incomplete.connect:before {
+  content: "1";
+}
+
+.connectDevice li.incomplete.sync:before {
+  content: "2";
+}
+
+.connectDevice li.complete h3 {
+  color: #868686;
+}
+
+.connectDevice li.complete p {
+  color: #bbb;
+}
+
+.connectDevice li.complete:before {
+  content: "✓";
+  background-color: #30e60b;
+  border: 1px solid #30e60b;
+  border-radius: 50%;
+}
+
+.connectDevice .desktopIcon:before,
+.connectDevice .mobileIcon:before,
+.connectDevice .mobileIcon:after {
+  content: "";
+  position: absolute;
+  left: -80px;
+  top: 8px;
+  background: linear-gradient(127deg, #00c8d7, #0060df);
+  mask: no-repeat 100% 100%;
+  mask-size: cover;
+  width: 64px;
+  height: 64px;
+}
+.connectDevice .desktopIcon:before {
+  mask-image: url(/icons/icon-desktop.svg);
+}
+
+.connectDevice .mobileIcon:before {
+  mask-image: url(/icons/icon-mobile.svg);
+}
+
+.connectDevice .mobileIcon:after {
+  mask-image: url(/icons/icon-download.svg);
+  width: 20px;
+  height: 22px;
+  left: -57px;
+  top: 27px;
+}

--- a/src/list/manage/containers/modals.css
+++ b/src/list/manage/containers/modals.css
@@ -1,15 +1,15 @@
-.connectDevice {
+.connect-device {
   width: 660px;
 }
 
-.connectDevice h1 {
+.connect-device h1 {
   font-size: 22px;
   line-height: 33px;
   font-weight: normal;
   margin-top: 0;
 }
 
-.connectDevice h2 {
+.connect-device h2 {
   font-size: 15px;
   line-height: 22.5px;
   font-weight: normal;
@@ -17,14 +17,14 @@
   margin: auto;
 }
 
-.connectDevice h3 {
+.connect-device h3 {
   font-size: 17px;
   line-height: 22.5px;
   font-weight: normal;
   display: inline;
 }
 
-.connectDevice li {
+.connect-device li {
   list-style-type: none;
   width: 480px;
   margin-left: auto;
@@ -34,19 +34,19 @@
   position: relative;
 }
 
-.connectDevice a {
+.connect-device a {
   color: #0060df;
   cursor: pointer;
 }
 
-.connectDevice p {
+.connect-device p {
   font-size: 15px;
   line-height: 22.5px;
   margin-top: 8px;
 }
 
-.connectDevice li.complete:before,
-.connectDevice li.incomplete:before {
+.connect-device li.complete:before,
+.connect-device li.incomplete:before {
   content: "";
   position: absolute;
   left: -40px;
@@ -57,7 +57,7 @@
   line-height: 24px;
 }
 
-.connectDevice li.incomplete:before {
+.connect-device li.incomplete:before {
   background-color: #ededf0;
   border: 1px solid #b1b1b3;
   border-radius: 50%;
@@ -67,32 +67,32 @@
 }
 
 /* this feels so hacky, but list item decimals don't allow backgrounds */
-.connectDevice li.incomplete.connect:before {
+.connect-device li.incomplete.connect:before {
   content: "1";
 }
 
-.connectDevice li.incomplete.sync:before {
+.connect-device li.incomplete.sync:before {
   content: "2";
 }
 
-.connectDevice li.complete h3 {
+.connect-device li.complete h3 {
   color: #868686;
 }
 
-.connectDevice li.complete p {
+.connect-device li.complete p {
   color: #bbb;
 }
 
-.connectDevice li.complete:before {
+.connect-device li.complete:before {
   content: "✓";
   background-color: #30e60b;
   border: 1px solid #30e60b;
   border-radius: 50%;
 }
 
-.connectDevice .desktopIcon:before,
-.connectDevice .mobileIcon:before,
-.connectDevice .mobileIcon:after {
+.connect-device .desktop-icon:before,
+.connect-device .mobile-icon:before,
+.connect-device .mobile-icon:after {
   content: "";
   position: absolute;
   left: -80px;
@@ -103,15 +103,15 @@
   width: 64px;
   height: 64px;
 }
-.connectDevice .desktopIcon:before {
+.connect-device .desktop-icon:before {
   mask-image: url(/icons/icon-desktop.svg);
 }
 
-.connectDevice .mobileIcon:before {
+.connect-device .mobile-icon:before {
   mask-image: url(/icons/icon-mobile.svg);
 }
 
-.connectDevice .mobileIcon:after {
+.connect-device .mobile-icon:after {
   mask-image: url(/icons/icon-download.svg);
   width: 20px;
   height: 22px;

--- a/src/list/manage/containers/modals.js
+++ b/src/list/manage/containers/modals.js
@@ -2,12 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { Localized } from "fluent-react";
+import PropTypes from "prop-types";
+import React from "react";
 import { connect } from "react-redux";
 
 import ModalRoot from "../../../widgets/modal-root";
 import { LocalizedConfirmDialog } from "../../../widgets/dialog-box";
-import { hideModal, removeItem, cancelEditing, selectItem } from
+import DialogBox from "../../../widgets/dialog-box";
+import { hideModal, removeItem, cancelEditing, selectItem, openHomepage, openSyncPrefs } from
        "../../actions";
+import { classNames } from "../../../common";
+
+import styles from "./modals.css";
 
 export const DeleteItemModal = connect(
   (state) => ({
@@ -31,9 +38,113 @@ export const CancelEditingModal = connect(
   }
 )(LocalizedConfirmDialog);
 
+export function ConnectDevice({profile, onClose, onDownloadClick, onSyncPrefsClick, ...props}) {
+  const isComplete = profile && profile.hasProfile && !profile.hasProfileNeedsAttn;
+
+  if (isComplete && profile.syncEnabled) {
+    return (
+      <DialogBox {...props}
+        buttons={[{name: "AllSet", label: "All Set", theme: "primary"}]}
+        onClick={() => {}}
+        onClose={onClose}>
+      <div className={styles.connectDevice} >
+        <Localized id="connect-another-device">
+          <h1>cOnNeCt aNoThEr dEvIcE</h1>
+        </Localized>
+        <Localized id="easily-access-logins">
+          <h2>eAsIlY GaIn aCcEsS To yOuR LoGiNs fRoM AnY DeViCe.</h2>
+        </Localized>
+        <ul>
+          <li className={styles.desktopIcon}>
+            <Localized id="access-on-another-computer">
+              <h3>aCcEsS On aNoThEr cOmPuTeR</h3>
+            </Localized>
+            <Localized id="simply-sign-in-other-device">
+              <p>sImPlY sIgN iN tO yOuR FiReFoX AcCoUnT On yOuR OtHeR DeViCe tO SyNc yOuR LoGiNs tO ThAt cOmPuTeR.</p>
+            </Localized>
+          </li>
+          <li className={styles.mobileIcon}>
+            <Localized id="download-mobile">
+              <h3>dOwNlOaD ThE MoBiLe aPp</h3>
+            </Localized>
+            <Localized id="download-ios-android"
+              learnmore={<a onClick={onDownloadClick}></a>}>
+              <p>fIrEfOx lOcKbOx iS AvAiLaBlE On bOtH IoS AnD AnDrOiD. <learnmore>cLiCk hErE</learnmore> To lEaRn mOrE AnD To sEnD A LiNk tO YoUr pHoNe tO DoWnLoAd tHe aPp.</p>
+            </Localized>
+          </li>
+        </ul>
+      </div>
+      </DialogBox>
+    );
+  }
+  return (
+    <DialogBox {...props}
+      buttons={[{name: "Close", theme: "primary", label: "Close"}]}
+      onClick={() => {}}
+      onClose={onClose}>
+    <div className={styles.connectDevice} >
+      <Localized id="connect-another-device">
+        <h1>cOnNeCt aNoThEr dEvIcE</h1>
+      </Localized>
+      <Localized id="before-access">
+        <h2>bEfOrE YoU CaN AcCeSs yOuR LoGiNs oN AnOtHeR DeViCe, YoU WiLl nEeD To cOnNeCt a fIrEfOx aCcOuNt.</h2>
+      </Localized>
+      <ol>
+        <li className={classNames([styles.connect, isComplete ? styles.complete : styles.incomplete])}>
+          { isComplete ? (
+            <Localized id="connect-a-firefox-account-complete"><h3>cOnNeCt a fIrEfOx aCcOuNt (cOmPlEtE)</h3></Localized>
+          ) : (
+            <Localized id="connect-a-firefox-account"><h3>cOnNeCt a fIrEfOx aCcOuNt</h3></Localized>
+          )}
+          <Localized id="sync-requires-account"
+            signin={<a onClick={() => onSyncPrefsClick("connect-device-step-one")}></a>}>
+            <p>tO SyNc yOuR LoGiNs tO AnOtHeR DeViCe, YoU WiLl nEeD To <signin>SiGn iN Or cReAtE A FiReFoX AcCoUnT</signin>.</p>
+          </Localized>
+        </li>
+        <li className={classNames([styles.sync, profile && profile.hasProfile && profile.syncEnabled ? styles.complete : styles.incomplete])}>
+          <Localized id="ensure-logins-checked">
+            <h3>eNsUrE ThE &ldquo;lOgInS&rdquo;cHeCkBoX Is sElEcTeD In sYnC PrEfErEnCeS</h3>
+          </Localized>
+          <Localized id="setting-to-allow-sync"
+            openprefs={<a onClick={() => onSyncPrefsClick("connect-device-step-two")}></a>}>
+            <p>iN OrDeR To aLlOw yOuR LoGiNs tO Be sYnCeD To oThEr dEvIcEs, ThIs sEtTiNg mUsT Be cHeCkEd. <openprefs>oPeN SyNc pReFeReNcEs</openprefs></p>
+          </Localized>
+        </li>
+      </ol>
+    </div>
+    </DialogBox>
+  );
+}
+
+ConnectDevice.propTypes = {
+  profile: PropTypes.object.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onDownloadClick: PropTypes.func.isRequired,
+  onSyncPrefsClick: PropTypes.func.isRequired,
+};
+
+export const ConnectDeviceModal = connect(
+  (state) => {
+    return {
+      l10nId: "modal-connect-another-device",
+      profile: {
+        hasProfile: state.app.profileWrap.hasProfile,
+        hasProfileNeedsAttn: state.app.profileWrap.hasProfileNeedsAttn,
+        syncEnabled: state.app.profileWrap.profile && state.app.profileWrap.profile.syncEnabled,
+      },
+    };
+  },
+  (dispatch) => ({
+    onClose: () => { dispatch(hideModal()); },
+    onDownloadClick: () => { dispatch(openHomepage()); },
+    onSyncPrefsClick: (menuitem) => { dispatch(openSyncPrefs(menuitem)); },
+  })
+)(ConnectDevice);
+
 const MODALS = {
   "delete": DeleteItemModal,
   "cancel-editing": CancelEditingModal,
+  "connect-another-device": ConnectDeviceModal,
 };
 
 export default connect(

--- a/src/list/manage/telemetry.js
+++ b/src/list/manage/telemetry.js
@@ -50,16 +50,18 @@ export default (store) => (next) => (action) => {
         object: "faq",
       });
       break;
+    // Clicking the mobile upsell opens the homepage
+    // TODO: differentiate between the connect modal and the display ad
+    case actions.OPEN_HOMEPAGE:
+      recordEvent({
+        method: "click",
+        object: "getMobile",
+      });
+      break;
     case actions.OPEN_FEEDBACK:
       recordEvent({
         method: "click",
         object: "giveFeedback",
-      });
-      break;
-    case actions.OPEN_GET_MOBILE:
-      recordEvent({
-        method: "click",
-        object: "getMobile",
       });
       break;
     case actions.OPEN_SYNC_PREFS:
@@ -98,6 +100,11 @@ export default (store) => (next) => (action) => {
           method: "show",
           object: "deleteConfirm",
           extra: { itemid: state.list.selectedItemId },
+        });
+      } else if (action.id === "connect-another-device") {
+        recordEvent({
+          method: "click",
+          object: "getMobile",
         });
       }
       break;

--- a/src/locales/en-US/list.ftl
+++ b/src/locales/en-US/list.ftl
@@ -201,6 +201,22 @@ modal-delete = Delete this Entry?
   .confirmLabel = Delete
   .cancelLabel = Cancel
 
+connect-another-device = Connect another device
+easily-access-logins = Easily gain access to your logins from any device.
+access-on-another-computer = Access on another computer
+# TODO should Firefox Account or Firefox Lockbox be localized in the following strings?
+simply-sign-in-other-device = Simply sign in to your Firefox Account on your other device to sync your logins to that computer.
+download-mobile = Download the mobile app
+download-ios-android = Firefox Lockbox is available on both iOS and Android. <learnmore>Click here</learnmore> to learn more and to send a link to your phone to download the app.
+before-access = Before you can access your logins on another device, you will need to connect a Firefox Account.
+connect-a-firefox-account = Connect a Firefox Account
+connect-a-firefox-account-complete = Connect a Firefox Account (complete)
+sync-requires-account = To sync your logins to another device, you will need to <signin>sign in or create a Firefox Account</signin>.
+# TODO this string seems funny. should Sync be capitalized? should Logins be in quotes? is Sync localized?
+ensure-logins-checked = Ensure the “Logins” checkbox is selected in sync preferences
+# TODO should Sync be capitalized? is Sync localized?
+setting-to-allow-sync = In order to allow your logins to be synced to other devices, this setting must be checked. <openprefs>Open sync preferences</openprefs></p>
+
 banner-promote-device =
   .title = { product-fulltitle }
   .details = Download our mobile app to take your passwords with you everywhere.

--- a/test/integration/sync-api-test.js
+++ b/test/integration/sync-api-test.js
@@ -216,6 +216,7 @@ describe("sync API", () => {
       email: "foo@example.com",
       id: "0123456789abcdef0123456789abcdef",
       displayName: null,
+      syncEnabled: true,
     },
     error: {
       status: "error",
@@ -223,6 +224,7 @@ describe("sync API", () => {
       email: "foo@example.com",
       id: "0123456789abcdef0123456789abcdef",
       displayName: null,
+      syncEnabled: true,
     },
   };
 

--- a/test/unit/list/manage/telemetry-test.js
+++ b/test/unit/list/manage/telemetry-test.js
@@ -166,7 +166,7 @@ describe("list > manage > telemetryLogger middleware", () => {
 
   it("record telemetry for clicking the get mobile link", async () => {
     telemetryLogger(store)(next)({
-      type: actions.OPEN_GET_MOBILE,
+      type: actions.OPEN_HOMEPAGE,
     });
     expect(listener).to.have.been.calledWith({
       type: "telemetry_event",

--- a/test/unit/list/reducers-test.js
+++ b/test/unit/list/reducers-test.js
@@ -527,6 +527,7 @@ describe("list > reducers", () => {
             avatar: "blah.jpg",
             displayName: "fox",
             email: "lockbox@example.com",
+            syncEnabled: true,
           },
         };
 
@@ -538,6 +539,7 @@ describe("list > reducers", () => {
             avatar: "blah.jpg",
             displayName: "fox",
             email: "lockbox@example.com",
+            syncEnabled: true,
           },
         });
       });
@@ -551,6 +553,7 @@ describe("list > reducers", () => {
             avatar: "blah.jpg",
             displayName: "fox",
             email: "lockbox@example.com",
+            syncEnabled: true,
           },
         };
 
@@ -562,6 +565,33 @@ describe("list > reducers", () => {
             avatar: "blah.jpg",
             displayName: "fox",
             email: "lockbox@example.com",
+            syncEnabled: true,
+          },
+        });
+      });
+
+      it("logins sync state", () => {
+        const action = {
+          type: actions.UPDATED_PROFILE,
+          actionId: 0,
+          profile: {
+            status: "ok",
+            avatar: "blah.jpg",
+            displayName: "fox",
+            email: "lockbox@example.com",
+            syncEnabled: false,
+          },
+        };
+
+        expect(profileReducer(undefined, action)).to.deep.equal({
+          hasProfile: true,
+          hasProfileNeedsAttn: false,
+          profile: {
+            status: "ok",
+            avatar: "blah.jpg",
+            displayName: "fox",
+            email: "lockbox@example.com",
+            syncEnabled: false,
           },
         });
       });


### PR DESCRIPTION
Fixes #97

## Testing and Review Notes

Steps to exercise the modal:

1. Open Lockwise management page
2. Click on the avatar menu at top-right, pick the 'connect another device' option
3. Modal is displayed
4. Click the link to sign in, but when you sign in to sync, uncheck the 'logins' sync checkbox
5. The modal should show the first, but not the second, item as completed
6. Go into sync prefs from the link in the second modal item, check the logins checkbox
7. The modal will show the second item as completed, then rapidly (you'll likely miss it) switch to a second view that invites the user to download the mobile app

If you close and reopen the modal at in-between stages of sync setup, you should go to the last screen you saw in the modal. If you re-disable logins sync, or sign out of sync, the modal will go back to the appropriate screen.


## Screenshots or Videos

Compare with: https://app.zeplin.io/project/5c1829b8fde4d550a26b270f/screen/5c47a86940cdef385c5614c9

First screen
<img width="1067" alt="Screen Shot 2019-04-29 at 10 01 02 AM" src="https://user-images.githubusercontent.com/96396/56913480-9b867700-6a66-11e9-84fe-d23d496435e6.png">

First screen, signed in and verified, but logins sync disabled
<img width="1067" alt="Screen Shot 2019-04-29 at 10 03 28 AM" src="https://user-images.githubusercontent.com/96396/56913478-9b867700-6a66-11e9-91b9-c4b0d4d79063.png">

Second screen, signed in, verified, and sync enabled
<img width="1067" alt="Screen Shot 2019-04-29 at 10 03 18 AM" src="https://user-images.githubusercontent.com/96396/56913479-9b867700-6a66-11e9-9c63-60ea7dc3343d.png">

There is a little bit of a weird UX state if you haven't verified email yet:

<img width="1067" alt="Screen Shot 2019-04-29 at 10 09 48 AM" src="https://user-images.githubusercontent.com/96396/56913639-06d04900-6a67-11e9-9caf-2414e8c4f419.png">


However, if you just re-follow the 'sign in or sign up' link in the modal's item 1, the sync preferences page tells you what to do:

<img width="944" alt="Screen Shot 2019-04-29 at 10 09 59 AM" src="https://user-images.githubusercontent.com/96396/56913638-06d04900-6a67-11e9-8013-d5e3ec64c20a.png">





## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
  - optional: consider adding integration tests
- [x] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [x] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-addon/developer/test-plan-accessibility/) of any added UI
- [ ] make sure any new UI has telemetry events wired up and documented in docs/metrics.md, and verify that the events are recording properly (visit `about:telemetry#events-tab`, then choose 'dynamic' from the dropdown menu at top right, to view events fired by the addon
