### PR TITLE
Clear error state when starting to add/edit an entry

### DIFF
--- a/src/list/manage/reducers.js
+++ b/src/list/manage/reducers.js
@@ -34,7 +34,7 @@ export function editorReducer(state = {
     return {...state, hideHome: false};
   case actions.START_NEW_ITEM:
   case actions.EDIT_CURRENT_ITEM:
-    return {...state, editing: true};
+    return {...state, editing: true,  error: null};
   case actions.EDITOR_CHANGED:
     return {...state, changed: true};
   case actions.CANCEL_EDITING:

--- a/test/unit/list/manage/mock-redux-state.js
+++ b/test/unit/list/manage/mock-redux-state.js
@@ -31,6 +31,7 @@ export const initialState = {
     editing: false,
     changed: false,
     hideHome: false,
+    error: null,
   },
   modal: {
     id: null,
@@ -81,6 +82,7 @@ export const filledState = {
     editing: false,
     changed: false,
     hideHome: false,
+    error: null,
   },
   modal: {
     id: null,

--- a/test/unit/list/manage/reducers-test.js
+++ b/test/unit/list/manage/reducers-test.js
@@ -171,6 +171,7 @@ describe("list > manage > reducers", () => {
         editing: true,
         changed: false,
         hideHome: false,
+        error: null,
       });
     });
 
@@ -183,6 +184,7 @@ describe("list > manage > reducers", () => {
         editing: true,
         changed: false,
         hideHome: false,
+        error: null,
       });
     });
 


### PR DESCRIPTION
Fixes #150

When the user clicks the "Edit" or "+" (add), this change clears the editor's error state.

## Testing and Review Notes

*Prerequisites*

The steps and expected outcome are documented in #150.

## Screenshots or Videos

![addon-150 on-add](https://user-images.githubusercontent.com/757401/56933143-d5c23980-6aa3-11e9-98d0-4ff2d01b38d3.gif)


## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)