### PR TITLE
Use the official lockbox icon throughout

### DIFF
--- a/src/background/browser-action.js
+++ b/src/background/browser-action.js
@@ -27,7 +27,7 @@ export default async function updateBrowserAction() {
   // XXXX: be more efficient with this?
   uninstallPopup();
 
-  const iconpath = "icons/lb_locked.svg";
+  const iconpath = "icons/icon-lockbox.svg";
   browser.browserAction.setIcon({ path: iconpath });
 
   return installEntriesAction();

--- a/src/manifest.json.tpl
+++ b/src/manifest.json.tpl
@@ -4,8 +4,8 @@
   "version": "{{version}}",
   "description": "{{description}}",
   "icons": {
-    "48": "icons/lb_locked.svg",
-    "96": "icons/lb_locked.svg"
+    "48": "icons/icon-lockbox.svg",
+    "96": "icons/icon-lockbox.svg"
   },
 
 
@@ -24,7 +24,7 @@
 
   "browser_action": {
     "default_icon": {
-      "32": "icons/lb_locked.svg"
+      "32": "icons/icon-lockbox.svg"
     },
     "default_title": "Lockbox",
     "browser_style": false

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -134,14 +134,14 @@ module.exports = {
       filename: "list/manage.html",
       chunks: ["list/manage"],
       inject: false,
-      icon: "/icons/lb_locked.svg",
+      icon: "/icons/icon-lockbox.svg",
     }),
     new HTMLWebpackPlugin({
       template: "template.ejs",
       filename: "list/popup.html",
       chunks: ["list/popup"],
       inject: false,
-      icon: "/icons/lb_locked.svg",
+      icon: "/icons/icon-lockbox.svg",
     }),
     new webpack.EnvironmentPlugin({
       NODE_ENV,


### PR DESCRIPTION
* toolbar button icon
* addon icon for about:addons page
* page favicon

Fixes #151, fixes #167.

## Screenshots or Videos

about:addons extensions list view:

<img width="430" alt="Screen Shot 2019-04-29 at 4 27 26 PM" src="https://user-images.githubusercontent.com/96396/56933290-ff776280-6a9b-11e9-8484-61f770cb81c1.png">

about:addons extension detail view:

<img width="430" alt="Screen Shot 2019-04-29 at 4 27 30 PM" src="https://user-images.githubusercontent.com/96396/56933291-ff776280-6a9b-11e9-8c1b-652976ab8c24.png">

lockbox icon as favicon in backgrounded tab:

<img width="278" alt="Screen Shot 2019-04-29 at 4 27 36 PM" src="https://user-images.githubusercontent.com/96396/56933292-ff776280-6a9b-11e9-95a2-504cc048d2bd.png">

lockbox icon in toolbar, wow so color:
<img width="190" alt="Screen Shot 2019-04-29 at 4 27 40 PM" src="https://user-images.githubusercontent.com/96396/56933293-000ff900-6a9c-11e9-8a34-c8d15ad0d84b.png">



## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding integration tests
- [ ] request the "UX" team perform a design review (if/when applicable)
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-addon/developer/test-plan-accessibility/) of any added UI
- [ ] make sure any new UI has telemetry events wired up and documented in docs/metrics.md, and verify that the events are recording properly (visit `about:telemetry#events-tab`, then choose 'dynamic' from the dropdown menu at top right, to view events fired by the addon
