### PR TITLE
Increase modal overlay z-index above list item pseudoelements

### DIFF
--- a/src/widgets/modal-root.css
+++ b/src/widgets/modal-root.css
@@ -11,6 +11,7 @@
 }
 
 .overlay {
+  z-index: 100;
   position: fixed;
   top: 0;
   bottom: 0;


### PR DESCRIPTION
Fixes #158.


## Screenshots or Videos

### before:

<img width="1078" alt="Screen Shot 2019-04-30 at 11 29 13 AM" src="https://user-images.githubusercontent.com/96396/56984589-3a7ca300-6b3b-11e9-8a12-bae78b8261fc.png">

### after:

<img width="1078" alt="Screen Shot 2019-04-30 at 11 29 06 AM" src="https://user-images.githubusercontent.com/96396/56984590-3a7ca300-6b3b-11e9-8340-d67aa26f3b83.png">