### PR TITLE
Correctly set sort label on manage page reload

### DIFF
--- a/src/list/manage/components/list-sort.js
+++ b/src/list/manage/components/list-sort.js
@@ -12,7 +12,7 @@ export default class ListSort extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      value: props.value,
+      value: props.sort,
     };
     this.handleChange = this.handleChange.bind(this);
   }


### PR DESCRIPTION
Fixes #171.

Quick fix, had missed a prop name change between the component and container.


## Testing and Review Notes

Have some logins, change the sort, reload the page, observe the sort label is still correct across page loads.

