### PR TITLE
Add an l10n.toml file to support string checks and linting.

### DIFF
--- a/l10n.toml
+++ b/l10n.toml
@@ -1,0 +1,9 @@
+basepath = "."
+
+locales = [
+  "fr-FR",
+]
+
+[[paths]]
+  reference = "src/locales/en-US/*.ftl"
+  l10n = "src/locales/{locale}/*.ftl"


### PR DESCRIPTION
With this file, and an installed compare-locales, you can run

```
moz-l10n-lint l10n.toml
```

to find problems in English, and

```
compare-locales l10n.toml .
```

to find problems and completion status in the localizations.

This file would also control where Pontoon finds reference files
and localizations.

PS: You install compare-locales with `pip install compare-locales`.

Connected to #193 

_(Optional: other issues or pull requests related to this, but merging should not close it)_

## Testing and Review Notes

Ran `moz-l10n-lint l10n.toml` locally, got:

```
src/locales/en-US/list.ftl (150:1): Duplicate string with ID: list-count
src/locales/en-US/list.ftl (152:1): Duplicate string with ID: list-count
src/locales/en-US/list.ftl (171:1): Duplicate string with ID: filtered-banner
src/locales/en-US/list.ftl (174:1): Duplicate string with ID: filtered-banner
```


## Screenshots or Videos

_(Optional: to clearly demonstrate the feature or fix to help with testing and reviews)_


## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] add unit tests
  - optional: consider adding integration tests
- [ ] request the "UX" team perform a design review (if/when applicable)
- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)
- [ ] check on the [accessibility](https://mozilla-lockbox.github.io/lockbox-addon/developer/test-plan-accessibility/) of any added UI
- [ ] make sure any new UI has telemetry events wired up and documented in docs/metrics.md, and verify that the events are recording properly (visit `about:telemetry#events-tab`, then choose 'dynamic' from the dropdown menu at top right, to view events fired by the addon
