### PR TITLE
Correct errors in fluent files

### DIFF
--- a/docs/developer/install.md
+++ b/docs/developer/install.md
@@ -1,5 +1,16 @@
 # Installing the Lockbox Addon
 
+## Prerequisites
+
+Before installing, you'll need the following:
+
+* [node](https://nodejs.org) (10.15 or higher)
+* [Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/) (Nightly or Developer Edition)
+
+For locales, you'll want the following:
+
+* [compare-locales](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/compare-locales)
+
 ## Installing dependencies
 
 To **install the project dependencies**, you can run:

--- a/docs/developer/install.md
+++ b/docs/developer/install.md
@@ -5,7 +5,7 @@
 Before installing, you'll need the following:
 
 * [node](https://nodejs.org) (10.15 or higher)
-* [Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/) (Nightly or Developer Edition)
+* [Firefox](https://www.mozilla.org/en-US/firefox/channel/desktop/) (version 67 or higher, Nightly or Developer Edition)
 
 For locales, you'll want the following:
 

--- a/src/locales/en-US/list.ftl
+++ b/src/locales/en-US/list.ftl
@@ -147,8 +147,7 @@ item-details-created = Created: {$date}
 item-details-modified = Last Modified: {$date}
 item-details-last-used = Last Used: {$date}
 
-list-count = {$count} entries
-
+# count is the number of items in the list
 list-count = { $count ->
   [one]   {$count} entry
  *[other] { $count } entries
@@ -169,8 +168,6 @@ list-detail-button = Open Website
 default-banner = Recently used entries.
 
 # count is the number of items matching the filter
-filtered-banner = {$count} entries found
-
 filtered-banner = { $count ->
   [one]   {$count} entry found
  *[other] { $count } entries found


### PR DESCRIPTION
This change fixes the technical errors in the existing fluent localization files.  It does **not** address the very large discrepancies between en-US and fr-FR locales.

Fixes #193

## Testing and Review Notes

0. Install `compare-locales`
1. run the following:

```sh
compare-locales l10n.toml .
```

And look for `WARNING` or `ERROR` notices.

## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)