### PR TITLE
Update timeLastUsed on password field copy

### DIFF
--- a/src/background/datastore.js
+++ b/src/background/datastore.js
@@ -188,6 +188,15 @@ class DataStore {
     }
     return item || null;
   }
+  async touch(id) {
+    const item = await this.get(id);
+    let touchedItem;
+    if (item) {
+      const touchedLogin = await browser.experiments.logins.touch(item.id);
+      touchedItem = convertInfo2Item(touchedLogin);
+    }
+    return touchedItem || null;
+  }
 
   // TODO: Until issue #21 is resolved, this stuff handles raw info from the
   // API rather than UI items.

--- a/src/background/message-ports.js
+++ b/src/background/message-ports.js
@@ -69,6 +69,15 @@ export default function initializeMessagePorts() {
       return {};
     case "copied_field":
       await clipboard.copyToClipboard(message.field, message.toCopy);
+      const ds = await openDataStore();
+      if (message.field === "password") {
+        try {
+          await ds.touch(message.item.id);
+        } catch (ex) {
+          // eslint-disable-next-line no-console
+          console.error("Unable to touch() login after password copy: ", ex);
+        }
+      }
       return {};
     case "get_profile":
       return getProfileInfo();

--- a/src/list/actions.js
+++ b/src/list/actions.js
@@ -294,6 +294,7 @@ export function copiedField(field, toCopy, item) {
       type: "copied_field",
       field,
       toCopy,
+      item,
     });
     dispatch(copiedFieldCompleted(actionId, field, item));
   };

--- a/test/unit/background/datastore-test.js
+++ b/test/unit/background/datastore-test.js
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { expect } from "chai";
+import chai, { expect } from "chai";
 import sinon from "sinon";
+import sinonChai from "sinon-chai";
 
 import "test/unit/mocks/browser";
 
@@ -14,6 +15,8 @@ import {
   convertInfo2Item,
   convertItem2Info,
 } from "src/background/datastore";
+
+chai.use(sinonChai);
 
 const LOGINS_METHODS = ["getAll", "add", "update", "remove"];
 const LOGINS_EVENTS = [
@@ -304,6 +307,22 @@ describe("background > datastore", () => {
 
     expect(resultApiInfo.timePasswordChanged).to.not.be.undefined;
     expect(resultApiInfo).to.deep.equal(expectedApiInfo);
+  });
+
+  it("allows an item's last used time to be updated via touch", async () => {
+    const sampleInfo = SAMPLE_INFOS.FOO;
+
+    const newTime = Date.now();
+    const mock = sinon.stub(browser.experiments.logins, "touch");
+    mock.returns(Object.assign({}, sampleInfo, {
+      timeLastUsed: newTime,
+    }));
+    const touchedItem = await store.touch("FOO");
+
+    expect(touchedItem.timeLastUsed).to.equal(newTime);
+    expect(mock).to.have.been.calledWith("FOO");
+
+    browser.experiments.logins.touch.restore();
   });
 
   it("allows an item to be removed", async () => {

--- a/test/unit/mocks/browser.js
+++ b/test/unit/mocks/browser.js
@@ -212,6 +212,7 @@ window.browser = {
       async remove(guid) {
         browser.experiments.logins.onRemoved.getListener()({ login: { guid } });
       },
+      async touch() { },
       onAdded: new MockListener(),
       onUpdated: new MockListener(),
       onRemoved: new MockListener(),


### PR DESCRIPTION
Fixes #157

## Testing and Review Notes

1. start lockbox via `npm run run`
2. create a new login manually in the manage UI
3. open the addon debugger via `about:debugging`, then get the original `timeLastUsed` via
```js
(await browser.experiments.logins.getAll())[0].timeLastUsed
```
4. copy the password field in the lockbox UI
5. check the `timeLastUsed` again; it should be updated
