### PR TITLE
Line up sort filter and label on windows

### DIFF
--- a/src/list/manage/components/item-list-panel.css
+++ b/src/list/manage/components/item-list-panel.css
@@ -33,6 +33,10 @@
   margin-top: 8px;
 }
 
+.second-row select {
+  line-height: 34px;
+}
+
 .item-filter {
   composes: item-filter from "../../../widgets/panel.css";
   background: #f3f3f5;

--- a/src/list/manage/components/item-list-panel.css
+++ b/src/list/manage/components/item-list-panel.css
@@ -36,7 +36,7 @@
 .item-filter {
   composes: item-filter from "../../../widgets/panel.css";
   background: #f3f3f5;
-  height: 32px;
+  height: 31px;
 }
 
 .flex-spacer {


### PR DESCRIPTION
Fixes #153 on windows, though on mac, the label's now misaligned.

Not sure how deep it's worth digging here, but if there are quick fixes I'm missing, feedback welcome :-)